### PR TITLE
Fix Service#at_year scope

### DIFF
--- a/api/app/models/service.rb
+++ b/api/app/models/service.rb
@@ -25,9 +25,7 @@ class Service < ApplicationRecord
 
   scope :at_date, ->(date) { where(arel_table[:beginning].lteq(date)).where(arel_table[:ending].gteq(date)) }
   scope :chronologically, -> { order(:beginning, :ending) }
-  # TODO: Check if this is correct (my opinion: should be overlapping_date_range, because Services with a beginning in
-  # last year and ending in current_year should be included in at_year(current_year) too)
-  scope :at_year, ->(year) { in_date_range(Date.new(year), Date.new(year).at_end_of_year) }
+  scope :at_year, ->(year) { overlapping_date_range(Date.new(year), Date.new(year).at_end_of_year) }
 
   delegate :identification_number, to: :service_specification
 

--- a/api/spec/models/service_spec.rb
+++ b/api/spec/models/service_spec.rb
@@ -18,11 +18,12 @@ RSpec.describe Service, type: :model do
 
     before do
       create_pair :service, beginning: '2018-11-05', ending: '2018-11-30'
+      create :service, beginning: '2017-02-06', ending: '2018-01-05'
       create :service, beginning: '2017-02-06', ending: '2017-02-24'
     end
 
-    it 'returns only services in this year' do
-      expect(services.count).to eq 2
+    it 'returns only services that are at least partially in this year' do
+      expect(services.count).to eq 3
     end
   end
 


### PR DESCRIPTION
Service#at_year should also return Services that are only partially in the supplied year.