### PR TITLE
better login failure feedback and stay on login page

### DIFF
--- a/frontend/src/stores/apiStore.ts
+++ b/frontend/src/stores/apiStore.ts
@@ -182,8 +182,14 @@ export class ApiStore {
       },
       (error: AxiosError) => {
         if (error.response && error.response.status === 401) {
-          console.log('Unauthorized API access, redirect to login'); // tslint:disable-line:no-console
-          if (error.config.url && !/\/users\/sign_out$/.test(error.config.url)) {
+          console.log('Unauthorized API access'); // tslint:disable-line:no-console
+
+          const comingFromLogout = error.config.url && /\/users\/sign_out$/.test(error.config.url);
+          const comingFromLogin = error.config.url && /\/users\/sign_in$/.test(error.config.url);
+
+          if (comingFromLogin) {
+            this.removeAuthorizationToken();
+          } else if (!comingFromLogout) {
             this.logout().catch(this.removeAuthorizationToken.bind(this));
           } else {
             this.removeAuthorizationToken();

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -39,9 +39,13 @@ export class Login extends React.Component<Props> {
     try {
       await this.props.apiStore!.postLogin(values);
       this.props.history.push(this.getReferrer());
-    } catch ({ error }) {
-      if (error.toString().includes('400')) {
+    } catch (error) {
+      if (error.error.toString().includes('400')) {
         this.props.mainStore!.displayError('Ungültiger Benutzername/Passwort');
+      } else if (error.messages.error != null) {
+        this.props.mainStore!.displayError(error.messages.error); // display errors messages from the server
+      } else if (error.error.message != null) {
+        this.props.mainStore!.displayError(error.error.message); // display error messages from the connection request
       } else {
         this.props.mainStore!.displayError('Ein interner Fehler ist aufgetreten. Bitte versuchen Sie es später erneut.');
       }


### PR DESCRIPTION
show better error feedback when a login fails and in case it fails, stay on the login page so the user can retry the login.