### PR TITLE
auto generate expense sheets, live update service days and sort sheets by date

### DIFF
--- a/api/app/controllers/v1/expense_sheets_controller.rb
+++ b/api/app/controllers/v1/expense_sheets_controller.rb
@@ -23,7 +23,7 @@ module V1
     ].freeze
 
     def index
-      @expense_sheets = filtered_expense_sheets.order(beginning: :desc, ending: :desc)
+      @expense_sheets = filtered_expense_sheets.order(beginning: :asc, ending: :asc)
     end
 
     def show

--- a/api/app/controllers/v1/expense_sheets_controller.rb
+++ b/api/app/controllers/v1/expense_sheets_controller.rb
@@ -23,7 +23,7 @@ module V1
     ].freeze
 
     def index
-      @expense_sheets = filtered_expense_sheets
+      @expense_sheets = filtered_expense_sheets.order(beginning: :desc, ending: :desc)
     end
 
     def show

--- a/api/app/controllers/v1/services_controller.rb
+++ b/api/app/controllers/v1/services_controller.rb
@@ -59,6 +59,8 @@ module V1
     def confirm
       raise ValidationError, @service.errors unless @service.update(confirmation_date: Time.zone.now)
 
+      ExpenseSheetGenerator.new(@service).create_expense_sheets
+
       render :show
     end
 

--- a/frontend/src/views/expense_sheets/expense_sheet_form/segments/AbsolvedDaysBreakdownSegment.tsx
+++ b/frontend/src/views/expense_sheets/expense_sheet_form/segments/AbsolvedDaysBreakdownSegment.tsx
@@ -11,14 +11,12 @@ export const AbsolvedDaysBreakdownSegment = expenseSheetFormSegment(
         horizontal
         appendedLabels={[`Vorschlag: ${hints.suggestions.work_days} Tage`]}
         component={NumberField}
-        defaultValue={hints.suggestions.work_days}
         name={'work_days'}
         label={'Gearbeitet'}
       />
       <WiredField
         horizontal
         appendedLabels={[`Vorschlag: ${hints.suggestions.workfree_days} Tage`]}
-        defaultValue={hints.suggestions.workfree_days}
         component={NumberField}
         name={'workfree_days'}
         label={'Arbeitsfrei'}
@@ -26,7 +24,6 @@ export const AbsolvedDaysBreakdownSegment = expenseSheetFormSegment(
       <WiredField
         horizontal
         appendedLabels={[`Übriges Guthaben: ${hints.remaining_days.sick_days} Tage`]}
-        defaultValue={hints.remaining_days.sick_days}
         component={NumberField}
         name={'sick_days'}
         label={'Krank'}

--- a/frontend/src/views/expense_sheets/expense_sheet_form/segments/AbsolvedDaysBreakdownSegment.tsx
+++ b/frontend/src/views/expense_sheets/expense_sheet_form/segments/AbsolvedDaysBreakdownSegment.tsx
@@ -11,12 +11,14 @@ export const AbsolvedDaysBreakdownSegment = expenseSheetFormSegment(
         horizontal
         appendedLabels={[`Vorschlag: ${hints.suggestions.work_days} Tage`]}
         component={NumberField}
+        defaultValue={hints.suggestions.work_days}
         name={'work_days'}
         label={'Gearbeitet'}
       />
       <WiredField
         horizontal
         appendedLabels={[`Vorschlag: ${hints.suggestions.workfree_days} Tage`]}
+        defaultValue={hints.suggestions.workfree_days}
         component={NumberField}
         name={'workfree_days'}
         label={'Arbeitsfrei'}
@@ -24,6 +26,7 @@ export const AbsolvedDaysBreakdownSegment = expenseSheetFormSegment(
       <WiredField
         horizontal
         appendedLabels={[`Übriges Guthaben: ${hints.remaining_days.sick_days} Tage`]}
+        defaultValue={hints.remaining_days.sick_days}
         component={NumberField}
         name={'sick_days'}
         label={'Krank'}

--- a/frontend/src/views/users/service_modal/ServiceModal.tsx
+++ b/frontend/src/views/users/service_modal/ServiceModal.tsx
@@ -41,34 +41,6 @@ export class ServiceModal extends React.Component<ServiceModalProps<Service>, { 
     },
   ];
 
-  private updateEndingOrServiceDays = debounce(async (current, next, formik) => {
-    this.autoUpdate = false;
-    const values = {
-      beginning: next.values.beginning,
-    };
-    for (const map of this.changeFieldsToUpdateFieldMap) {
-      const [firstIndex, secondIndex] = map.changes;
-
-      if (!next.values[firstIndex] || !next.values[secondIndex]) {
-        continue;
-      }
-
-      const firstIndexUnchanged = current.values[firstIndex] === next.values[firstIndex];
-      const secondIndexUnchanged = current.values[secondIndex] === next.values[secondIndex];
-      if (firstIndexUnchanged && secondIndexUnchanged) {
-        continue;
-      }
-
-      values[secondIndex] = next.values[secondIndex];
-      const data = await this.props.serviceStore!.calcServiceDaysOrEnding(values);
-      if (data && data.result) {
-        formik.setFieldValue(map.updateField, data.result);
-      }
-      break;
-    }
-    this.autoUpdate = true;
-  }, 500);
-
   constructor(props: ServiceModalProps<Service>) {
     super(props);
     this.initialValues = props.service || {
@@ -97,7 +69,12 @@ export class ServiceModal extends React.Component<ServiceModalProps<Service>, { 
 
   handleServiceDateRangeChange: OnChange<Service> = async (current, next, formik) => {
     if (this.autoUpdate) {
-      await this.updateEndingOrServiceDays(current, next, formik);
+      await this.updateEndingOrServiceDays(current, next, formik).catch(() => {
+        // tslint:disable-next-line:no-console
+        console.error('Failed to calculate ending or service days automatically...');
+        // reset auto update
+        this.autoUpdate = true;
+      });
     }
   }
 
@@ -161,5 +138,36 @@ export class ServiceModal extends React.Component<ServiceModalProps<Service>, { 
       // TODO: remove reload (layzness)
       setTimeout(() => window.location.reload(), 2000);
     });
+  }
+
+  private updateEndingOrServiceDays = async (current: any, next: any, formik: any) => {
+    this.autoUpdate = false;
+
+    const values = {
+      beginning: next.values.beginning,
+    };
+
+    for (const map of this.changeFieldsToUpdateFieldMap) {
+      const [firstIndex, secondIndex] = map.changes;
+
+      if (!next.values[firstIndex] || !next.values[secondIndex]) {
+        continue;
+      }
+
+      const firstIndexUnchanged = current.values[firstIndex] === next.values[firstIndex];
+      const secondIndexUnchanged = current.values[secondIndex] === next.values[secondIndex];
+
+      if (firstIndexUnchanged && secondIndexUnchanged) {
+        continue;
+      }
+
+      values[secondIndex] = next.values[secondIndex];
+      const data = await this.props.serviceStore!.calcServiceDaysOrEnding(values);
+      if (data && data.result) {
+        formik.setFieldValue(map.updateField, data.result);
+      }
+      break;
+    }
+    this.autoUpdate = true;
   }
 }


### PR DESCRIPTION
- generate expense sheets automatically when we accept a civil service
- live update service days when we select a beginning and ending of a service
- sort expense sheets by their beginning and end date

this closes #284 #279 #283 #281 