### PR TITLE
disallow deletion of services withe expense sheets and some other minor updates

### DIFF
--- a/api/app/controllers/v1/expense_sheets_controller.rb
+++ b/api/app/controllers/v1/expense_sheets_controller.rb
@@ -23,7 +23,7 @@ module V1
     ].freeze
 
     def index
-      @expense_sheets = filtered_expense_sheets
+      @expense_sheets = filtered_expense_sheets.order(beginning: :asc, ending: :asc)
     end
 
     def show

--- a/api/app/controllers/v1/services_controller.rb
+++ b/api/app/controllers/v1/services_controller.rb
@@ -59,6 +59,8 @@ module V1
     def confirm
       raise ValidationError, @service.errors unless @service.update(confirmation_date: Time.zone.now)
 
+      ExpenseSheetGenerator.new(@service).create_expense_sheets
+
       render :show
     end
 

--- a/api/app/views/v1/services/_service.json.jbuilder
+++ b/api/app/views/v1/services/_service.json.jbuilder
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+Jbuilder.key_format ->(key) { key.to_s.chomp('?') }
+
 json.extract! service, :id, :user_id, :beginning, :ending,
               :confirmation_date, :eligible_paid_vacation_days, :service_type, :first_swo_service,
-              :long_service, :probation_service, :service_days, :service_specification_id
+              :long_service, :probation_service, :service_days, :service_specification_id, :deletable?
 json.service_specification do
   json.extract! service.service_specification, :identification_number, :name
 end

--- a/frontend/src/form/DeleteButton.tsx
+++ b/frontend/src/form/DeleteButton.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Tooltip } from 'reactstrap';
 import Button from 'reactstrap/lib/Button';
 import ConfirmationDialog from './ConfirmationDialog';
 
@@ -6,15 +7,19 @@ interface DeleteButtonProps {
   onConfirm: () => void;
   message?: string;
   disabled?: boolean;
+  id?: string;
+  tooltip?: string;
 }
 
 interface DeleteButtonState {
   open: boolean;
+  tooltipOpen: boolean;
 }
 
 export class DeleteButton extends React.Component<DeleteButtonProps, DeleteButtonState> {
   state = {
     open: false,
+    tooltipOpen: false,
   };
 
   handleOpen = () => {
@@ -30,15 +35,54 @@ export class DeleteButton extends React.Component<DeleteButtonProps, DeleteButto
     this.handleClose();
   }
 
+  getDeleteButton = () => {
+    return (
+      <Button
+        disabled={this.props.disabled}
+        style={this.props.disabled ? { pointerEvents: 'none' } : undefined}
+        onClick={this.handleOpen}
+        color={'danger'}
+        type={'button'}
+      >
+        {this.props.children}
+      </Button>
+    );
+  }
+
+  getDeleteButtonWithTooltipWrapper = () => {
+    if (this.props.id && this.props.tooltip) {
+      return (
+        <div id={'DeleteButtonWrapper-' + this.props.id} style={{ display: 'inline-block' }}>
+          {this.getDeleteButton()}
+        </div>
+      );
+    } else {
+      return this.getDeleteButton();
+    }
+  }
+
   render = () => {
+    const tooltipOpen = this.state.tooltipOpen;
+    const toggle = () => this.setState({ tooltipOpen: !tooltipOpen });
+
     return (
       <>
         <ConfirmationDialog onClose={this.handleClose} onConfirm={this.handleConfirm} open={this.state.open} title={'Löschen'}>
           {this.props.message ? this.props.message : 'Wirklich löschen?'}
         </ConfirmationDialog>
-        <Button disabled={this.props.disabled} onClick={this.handleOpen} color={'danger'} type={'button'}>
-          {this.props.children}
-        </Button>
+        {this.getDeleteButtonWithTooltipWrapper()}
+        {this.props.id && this.props.tooltip && (
+          <Tooltip
+            trigger={'hover focus'}
+            delay={{ show: 100, hide: 100 }}
+            placement={'top'}
+            isOpen={tooltipOpen}
+            target={'DeleteButtonWrapper-' + this.props.id}
+            toggle={toggle}
+          >
+            {this.props.tooltip}
+          </Tooltip>
+        )}
       </>
     );
   }

--- a/frontend/src/layout/IziviContent.tsx
+++ b/frontend/src/layout/IziviContent.tsx
@@ -22,6 +22,11 @@ const styles = (theme: Theme) =>
         margin: 0,
       },
     },
+    limitedContainer: {
+      '@media (min-width: 1250px)': {
+        maxWidth: '1200px',
+      },
+    },
     background: {
       backgroundImage: `url(${bg})`,
       backgroundSize: 'cover',
@@ -57,7 +62,7 @@ class IziviContent extends React.Component<Props> {
       this.props.className,
       classes.container,
       { [classes.background]: showBackgroundImage },
-      (!this.props.showBackgroundImage && !this.props.fullscreen ? 'container' : undefined),
+      (!this.props.showBackgroundImage && !this.props.fullscreen ? ['container', classes.limitedContainer] : undefined),
     );
 
     return (

--- a/frontend/src/stores/apiStore.ts
+++ b/frontend/src/stores/apiStore.ts
@@ -111,6 +111,11 @@ export class ApiStore {
 
   @action
   async postLogin(values: { email: string; password: string }) {
+    // remove the authorization token if it is expired already in order to fix the multiple login issue
+    if (Boolean(this._token) && moment.unix(this.userInfo!.exp).isBefore()) {
+      this.removeAuthorizationToken();
+    }
+
     const res = await this._api.post<LoginResponse>('/users/sign_in', { user: values });
     runInAction(() => {
       this.setToken(res.headers.authorization);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -189,6 +189,7 @@ export interface Service {
   long_service: boolean;
   service_type: string | null;
   probation_period: boolean;
+  deletable: boolean;
   service_specification_id: number;
   service_specification: {
     identification_number: string;

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -40,12 +40,14 @@ export class Login extends React.Component<Props> {
       await this.props.apiStore!.postLogin(values);
       this.props.history.push(this.getReferrer());
     } catch (error) {
-      if (error.error.toString().includes('400')) {
-        this.props.mainStore!.displayError('Ungültiger Benutzername/Passwort');
-      } else if (error.messages.error != null) {
+      // tslint:disable-next-line:no-console
+      console.log(error);
+      if (error.messages != null && error.messages.error != null) {
         this.props.mainStore!.displayError(error.messages.error); // display errors messages from the server
-      } else if (error.error.message != null) {
+      } else if (error.error != null && error.error.message != null) {
         this.props.mainStore!.displayError(error.error.message); // display error messages from the connection request
+      } else if (error.error != null && error.error.toString().includes('400')) {
+        this.props.mainStore!.displayError('Ungültiger Benutzername/Passwort');
       } else {
         this.props.mainStore!.displayError('Ein interner Fehler ist aufgetreten. Bitte versuchen Sie es später erneut.');
       }

--- a/frontend/src/views/service_specification/ServiceSpecificationsOverview.tsx
+++ b/frontend/src/views/service_specification/ServiceSpecificationsOverview.tsx
@@ -69,7 +69,7 @@ export class ServiceSpecificationsOverviewInner extends React.Component<ServiceS
     const serviceSpecifications = this.props.serviceSpecificationStore!.entities;
 
     return (
-      <IziviContent loading={this.state.loading} title={'Pflichtenheft'} card={true} fullscreen>
+      <IziviContent loading={this.state.loading} title={'Pflichtenheft'} card fullscreen>
         <ServiceSpecificationsOverviewTable classes={this.props.classes} theme={this.props.theme}>
           <Formik
             validationSchema={serviceSpecificationSchema}

--- a/frontend/src/views/users/schemas.ts
+++ b/frontend/src/views/users/schemas.ts
@@ -30,6 +30,7 @@ export const serviceSchema = yup.object({
   first_swo_service: yup.boolean(),
   long_service: yup.boolean(),
   probation_period: yup.boolean(),
+  deletable: yup.boolean().nullable(true),
   confirmation_date: yup.string().nullable(true),
   eligible_paid_vacation_days: yup.number(),
   feedback_done: yup.boolean(),

--- a/frontend/src/views/users/service_modal/ServiceModal.tsx
+++ b/frontend/src/views/users/service_modal/ServiceModal.tsx
@@ -53,6 +53,7 @@ export class ServiceModal extends React.Component<ServiceModalProps<Service>, { 
       long_service: false,
       probation_period: false,
       confirmation_date: null,
+      deletable: true,
       eligible_paid_vacation_days: 0,
       user_id: props.user.id,
       service_specification: {

--- a/frontend/src/views/users/service_modal/ServiceModal.tsx
+++ b/frontend/src/views/users/service_modal/ServiceModal.tsx
@@ -41,34 +41,6 @@ export class ServiceModal extends React.Component<ServiceModalProps<Service>, { 
     },
   ];
 
-  private updateEndingOrServiceDays = debounce(async (current, next, formik) => {
-    this.autoUpdate = false;
-    const values = {
-      beginning: next.values.beginning,
-    };
-    for (const map of this.changeFieldsToUpdateFieldMap) {
-      const [firstIndex, secondIndex] = map.changes;
-
-      if (!next.values[firstIndex] || !next.values[secondIndex]) {
-        continue;
-      }
-
-      const firstIndexUnchanged = current.values[firstIndex] === next.values[firstIndex];
-      const secondIndexUnchanged = current.values[secondIndex] === next.values[secondIndex];
-      if (firstIndexUnchanged && secondIndexUnchanged) {
-        continue;
-      }
-
-      values[secondIndex] = next.values[secondIndex];
-      const data = await this.props.serviceStore!.calcServiceDaysOrEnding(values);
-      if (data && data.result) {
-        formik.setFieldValue(map.updateField, data.result);
-      }
-      break;
-    }
-    this.autoUpdate = true;
-  }, 500);
-
   constructor(props: ServiceModalProps<Service>) {
     super(props);
     this.initialValues = props.service || {
@@ -97,7 +69,12 @@ export class ServiceModal extends React.Component<ServiceModalProps<Service>, { 
 
   handleServiceDateRangeChange: OnChange<Service> = async (current, next, formik) => {
     if (this.autoUpdate) {
-      await this.updateEndingOrServiceDays(current, next, formik);
+      await this.updateEndingOrServiceDays(current, next, formik).catch(() => {
+        // tslint:disable-next-line:no-console
+        console.error('Failed to calculate ending or service days automatically...');
+        // reset auto update
+        this.autoUpdate = true;
+      });
     }
   }
 
@@ -161,5 +138,36 @@ export class ServiceModal extends React.Component<ServiceModalProps<Service>, { 
       // TODO: remove reload (layzness)
       setTimeout(() => window.location.reload(), 2000);
     });
+  }
+
+  private updateEndingOrServiceDays = async (current: any, next: any, formik: any) => {
+    this.autoUpdate = false;
+
+    const values = {
+      beginning: next.values.beginning,
+    };
+
+    for (const map of this.changeFieldsToUpdateFieldMap) {
+      const [firstIndex, secondIndex] = map.changes;
+
+      if (!next.values[firstIndex] || !next.values[secondIndex]) {
+        continue;
+      }
+
+      const firstIndexUnchanged = current.values[firstIndex] === next.values[firstIndex];
+      const secondIndexUnchanged = current.values[secondIndex] === next.values[secondIndex];
+
+      if (firstIndexUnchanged && secondIndexUnchanged) {
+        continue;
+      }
+
+      values[secondIndex] = next.values[secondIndex];
+      const data = await this.props.serviceStore!.calcServiceDaysOrEnding(values);
+      if (data && data.result) {
+        formik.setFieldValue(map.updateField, data.result);
+      }
+      break;
+    }
+    this.autoUpdate = true;
   }
 }

--- a/frontend/src/views/users/service_subform/ServiceOverviewTable.tsx
+++ b/frontend/src/views/users/service_subform/ServiceOverviewTable.tsx
@@ -132,7 +132,12 @@ export default (params: OverviewTableParams) => {
   function adminButtons(service: Service) {
     return mainStore!.isAdmin() && (
       <>
-        <DeleteButton onConfirm={() => onServiceDeleteConfirm(service, serviceStore!, userStore!)}>
+        <DeleteButton
+          id={service.id ? 'Service-' + service.id.toString() : ''}
+          onConfirm={() => onServiceDeleteConfirm(service, serviceStore!, userStore!)}
+          disabled={!service.deletable}
+          tooltip={service.deletable ? undefined : 'Zuerst Spesenblätter löschen!'}
+        >
           <FontAwesomeIcon icon={TrashAltRegularIcon}/> <span>Löschen</span>
         </DeleteButton>{' '}
         {


### PR DESCRIPTION
- prevent the user from deleting services with expense sheets 
- auto generate expense sheets when an admin accepts a civil service
- update the service days when we adjust the ending date of a service
- sort the expense sheets by date instead of grouping them by name