### PR TITLE
360 shorten service

### DIFF
--- a/api/app/models/concerns/date_range_filterable.rb
+++ b/api/app/models/concerns/date_range_filterable.rb
@@ -19,7 +19,7 @@ module Concerns
 
       # All instances with an ending after the given date
       scope :after_date, (lambda do |ending|
-        where(arel_table[:ending].gteq(ending))
+        where(arel_table[:ending].gt(ending))
       end)
 
       # All instances whose beginning and ending range is fully or partially covering the passed date range

--- a/api/app/models/concerns/date_range_filterable.rb
+++ b/api/app/models/concerns/date_range_filterable.rb
@@ -17,6 +17,11 @@ module Concerns
           .where(arel_table[:ending].gteq(ending))
       end)
 
+      # All instances with an ending after the given date
+      scope :after_date, (lambda do |ending|
+        where(arel_table[:ending].gteq(ending))
+      end)
+
       # All instances whose beginning and ending range is fully or partially covering the passed date range
       scope :overlapping_date_range, (lambda do |beginning, ending|
         where(arel_table[:beginning].lteq(ending))

--- a/api/app/models/concerns/date_range_filterable.rb
+++ b/api/app/models/concerns/date_range_filterable.rb
@@ -17,9 +17,17 @@ module Concerns
           .where(arel_table[:ending].gteq(ending))
       end)
 
-      # All instances with an ending after the given date
-      scope :after_date, (lambda do |ending|
+      # All instances with an ending after the given date and a beginning before the given date
+      scope :after_end, (lambda do |ending|
         where(arel_table[:ending].gt(ending))
+          .where(arel_table[:beginning].lteq(ending))
+      end)
+
+      # All instances with an beginning before the given date and with an ending after the given date
+      scope :before_begin, (lambda do |beginning|
+        where(arel_table[:ending].gteq(beginning))
+          .where(arel_table[:beginning].lt(beginning))
+
       end)
 
       # All instances whose beginning and ending range is fully or partially covering the passed date range

--- a/api/app/models/concerns/date_range_filterable.rb
+++ b/api/app/models/concerns/date_range_filterable.rb
@@ -27,7 +27,6 @@ module Concerns
       scope :before_begin, (lambda do |beginning|
         where(arel_table[:ending].gteq(beginning))
           .where(arel_table[:beginning].lt(beginning))
-
       end)
 
       # All instances whose beginning and ending range is fully or partially covering the passed date range

--- a/api/app/models/service.rb
+++ b/api/app/models/service.rb
@@ -85,7 +85,7 @@ class Service < ApplicationRecord
 
   def check_if_service_can_be_shorten?
     sheets_in_range = user.expense_sheets.after_date(ending + 1)
-    errors.add(:service_days, :cannot_be_shortened) if not sheets_in_range.empty?
+    errors.add(:service_days, :cannot_be_shortened) unless sheets_in_range.empty?
   end
 
   def date_range

--- a/api/app/models/service.rb
+++ b/api/app/models/service.rb
@@ -84,8 +84,10 @@ class Service < ApplicationRecord
   end
 
   def check_if_service_can_be_shorten?
-    sheets_to_be_deleted = Service.where(user: user).where(id: id).after_date(ending)
-    errors.add(:service_days, :cannot_be_shortened) unless sheets_to_be_deleted.empty?
+    sheets_to_be_deleted_at_ending = user.expense_sheets.after_end(ending)
+    sheets_to_be_deleted_at_start = user.expense_sheets.before_begin(beginning)
+    errors.add(:service_days, :cannot_be_shortened) unless sheets_to_be_deleted_at_start.count.zero?
+    errors.add(:service_days, :cannot_be_shortened) unless sheets_to_be_deleted_at_ending.count.zero?
   end
 
   def date_range

--- a/api/app/models/service.rb
+++ b/api/app/models/service.rb
@@ -86,8 +86,8 @@ class Service < ApplicationRecord
   def check_if_service_can_be_shorten?
     sheets_to_be_deleted_at_ending = user.expense_sheets.after_end(ending)
     sheets_to_be_deleted_at_start = user.expense_sheets.before_begin(beginning)
-    errors.add(:service_days, :cannot_be_shortened) unless sheets_to_be_deleted_at_start.count.zero?
-    errors.add(:service_days, :cannot_be_shortened) unless sheets_to_be_deleted_at_ending.count.zero?
+    errors.add(:service_days, :cannot_be_shortened) unless sheets_to_be_deleted_at_start.empty?
+    errors.add(:service_days, :cannot_be_shortened) unless sheets_to_be_deleted_at_ending.empty?
   end
 
   def date_range

--- a/api/app/models/service.rb
+++ b/api/app/models/service.rb
@@ -27,6 +27,7 @@ class Service < ApplicationRecord
   validate :beginning_is_monday
   validate :no_overlapping_service
   validate :length_is_valid
+  validate :check_if_service_can_be_shorten?
   validate :validate_iban, on: :create, unless: :no_user?
 
   scope :at_date, ->(date) { where(arel_table[:beginning].lteq(date)).where(arel_table[:ending].gteq(date)) }
@@ -80,6 +81,11 @@ class Service < ApplicationRecord
   def deletable?
     sheets_in_range = user.expense_sheets.in_date_range(beginning, ending)
     sheets_in_range.nil? || sheets_in_range.count.zero?
+  end
+
+  def check_if_service_can_be_shorten?
+    sheets_in_range = user.expense_sheets.after_date(ending + 1)
+    errors.add(:service_days, :cannot_be_shortened) if not sheets_in_range.empty?
   end
 
   def date_range

--- a/api/app/models/service.rb
+++ b/api/app/models/service.rb
@@ -25,9 +25,9 @@ class Service < ApplicationRecord
 
   validate :ending_is_friday, unless: :last_civil_service?
   validate :beginning_is_monday
+  validate :check_if_service_can_be_shorten?
   validate :no_overlapping_service
   validate :length_is_valid
-  validate :check_if_service_can_be_shorten?
   validate :validate_iban, on: :create, unless: :no_user?
 
   scope :at_date, ->(date) { where(arel_table[:beginning].lteq(date)).where(arel_table[:ending].gteq(date)) }
@@ -84,8 +84,8 @@ class Service < ApplicationRecord
   end
 
   def check_if_service_can_be_shorten?
-    sheets_in_range = user.expense_sheets.after_date(ending + 1)
-    errors.add(:service_days, :cannot_be_shortened) unless sheets_in_range.empty?
+    sheets_to_be_deleted = Service.where(user: user).where(id: id).after_date(ending)
+    errors.add(:service_days, :cannot_be_shortened) unless sheets_to_be_deleted.empty?
   end
 
   def date_range

--- a/api/app/models/service.rb
+++ b/api/app/models/service.rb
@@ -25,7 +25,7 @@ class Service < ApplicationRecord
 
   validate :ending_is_friday, unless: :last_civil_service?
   validate :beginning_is_monday
-  validate :check_if_service_can_be_shorten?
+  validate :check_if_service_can_be_shorten?, on: :update
   validate :no_overlapping_service
   validate :length_is_valid
   validate :validate_iban, on: :create, unless: :no_user?

--- a/api/config/locales/de.yml
+++ b/api/config/locales/de.yml
@@ -119,6 +119,7 @@ de:
               unknown_country_code: unbekannter Landescode
             service_days:
               invalid_length: kann nicht kürzer als 26 Tage sein.
+              cannot_be_shortened: kann nicht gekürzt werden, wenn du nicht die vorher die nicht gebrauchten Spesenblätter löschst.
         user:
           attributes:
             bank_iban:

--- a/api/config/locales/de.yml
+++ b/api/config/locales/de.yml
@@ -118,8 +118,8 @@ de:
               bad_length: ungültige Länge
               unknown_country_code: unbekannter Landescode
             service_days:
-              invalid_length: kann nicht kürzer als 26 Tage sein.
               cannot_be_shortened: kann nicht gekürzt werden, wenn du nicht die vorher die nicht gebrauchten Spesenblätter löschst.
+              invalid_length: kann nicht kürzer als 26 Tage sein.
         user:
           attributes:
             bank_iban:

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -118,8 +118,8 @@ en:
               bad_length: bad length
               unknown_country_code: unknown country code
             service_days:
-              invalid_length: can not be less then 26.
               cannot_be_shortened: cannot be shortened, if you don't delete the expenses sheets, which aren't needed anymore.
+              invalid_length: can not be less then 26.
         user:
           attributes:
             bank_iban:

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -119,6 +119,7 @@ en:
               unknown_country_code: unknown country code
             service_days:
               invalid_length: can not be less then 26.
+              cannot_be_shortened: cannot be shortened, if you don't delete the expenses sheets, which aren't needed anymore.
         user:
           attributes:
             bank_iban:

--- a/api/config/locales/fr.yml
+++ b/api/config/locales/fr.yml
@@ -119,6 +119,7 @@ fr:
               unknown_country_code: code de pays inconnu
             service_days:
               invalid_length: ne peut être inférieure à 26 jours.
+              cannot_be_shortened: peut être réduite si vous ne supprimez pas au préalable les notes de frais non utilisées.
         user:
           attributes:
             bank_iban:

--- a/api/config/locales/fr.yml
+++ b/api/config/locales/fr.yml
@@ -118,8 +118,8 @@ fr:
               bad_length: longueur incorrecte
               unknown_country_code: code de pays inconnu
             service_days:
-              invalid_length: ne peut être inférieure à 26 jours.
               cannot_be_shortened: peut être réduite si vous ne supprimez pas au préalable les notes de frais non utilisées.
+              invalid_length: ne peut être inférieure à 26 jours.
         user:
           attributes:
             bank_iban:


### PR DESCRIPTION
fixes #171 there would be a better fix if expense_sheets would have a field for the corresponding service. This is more of a workaround because it's still sometimes possible to shorten the service without deleting all expense sheets. If the beggining or ending is in another month than previosly, the existance of the first or last expense sheets is not detected if the second or second last expense sheet is deleted.