### PR TITLE
380 false ending

### DIFF
--- a/frontend/src/views/service_overview/ServiceOverview.tsx
+++ b/frontend/src/views/service_overview/ServiceOverview.tsx
@@ -49,25 +49,6 @@ class ServiceOverviewContent extends React.Component<ServiceOverviewProps, Servi
   currYear = moment().year();
   intl: IntlShape;
 
-  getNrWeeks(): void {
-    const localCookieYear = window.localStorage.getItem(this.cookieYear);
-    const fetchYear = localCookieYear == null ? this.currYear.toString() : localCookieYear!;
-    const lastWeek = moment()
-      .year(parseInt(fetchYear, 10))
-      .isoWeek(53)
-      .isoWeekday(4)
-      .toDate();
-    if (moment(lastWeek).year() === parseInt(fetchYear, 10)) {
-      this.setState({
-        totalWeeks: 53
-      })
-    } else {
-      this.setState({
-        totalWeeks: 52
-      })
-    }
-  }
-
   constructor(props: ServiceOverviewProps) {
     super(props);
 
@@ -91,6 +72,25 @@ class ServiceOverviewContent extends React.Component<ServiceOverviewProps, Servi
     });
 
     this.intl = this.props.mainStore!.intl;
+  }
+
+  getNrWeeks(): void {
+    const localCookieYear = window.localStorage.getItem(this.cookieYear);
+    const fetchYear = localCookieYear == null ? this.currYear.toString() : localCookieYear!;
+    const lastWeek = moment()
+      .year(parseInt(fetchYear, 10))
+      .isoWeek(53)
+      .isoWeekday(4)
+      .toDate();
+    if (moment(lastWeek).year() === parseInt(fetchYear, 10)) {
+      this.setState({
+        totalWeeks: 53,
+      });
+    } else {
+      this.setState({
+        totalWeeks: 52,
+      });
+    }
   }
 
   componentDidMount(): void {
@@ -517,7 +517,7 @@ class ServiceOverviewContent extends React.Component<ServiceOverviewProps, Servi
     } else if (endWeek !== 53) {
       return week > startWeek && week < endWeek;
     } else {
-      return false
+      return false;
     }
   }
 
@@ -528,7 +528,7 @@ class ServiceOverviewContent extends React.Component<ServiceOverviewProps, Servi
     } else if (endWeek !== 53) {
       return week === endWeek;
     } else {
-      return false
+      return false;
     }
   }
 
@@ -556,7 +556,7 @@ class ServiceOverviewContent extends React.Component<ServiceOverviewProps, Servi
 
   getEndWeek(service: ServiceCollection): number {
     let endWeek = moment(service.ending!).isoWeek();
-    if (moment(service.ending!).year() > parseInt(this.state.fetchYear, 10) && endWeek != 53) {
+    if (moment(service.ending!).year() > parseInt(this.state.fetchYear, 10) && endWeek !== 53) {
       endWeek = 55;
     }
     return endWeek;

--- a/frontend/src/views/service_overview/ServiceOverview.tsx
+++ b/frontend/src/views/service_overview/ServiceOverview.tsx
@@ -75,6 +75,9 @@ class ServiceOverviewContent extends React.Component<ServiceOverviewProps, Servi
   }
 
   getNrWeeks(): void {
+    /* Since not all years have 52 weeks in the iso week date format
+    (some have 53, 2020/2026 for example)
+    this function sets totalWeeks to 52 or 53 for the whole class */
     const localCookieYear = window.localStorage.getItem(this.cookieYear);
     const fetchYear = localCookieYear == null ? this.currYear.toString() : localCookieYear!;
     const lastWeek = moment()
@@ -82,6 +85,9 @@ class ServiceOverviewContent extends React.Component<ServiceOverviewProps, Servi
       .isoWeek(53)
       .isoWeekday(4)
       .toDate();
+    /* lastWeek defines the last thursday in the last week with the beginning in
+    fetchYear, because of it's importance to
+    determine if the year has 52 or 53 weeks */
     if (moment(lastWeek).year() === parseInt(fetchYear, 10)) {
       this.setState({
         totalWeeks: 53,


### PR DESCRIPTION
Since not all years have 52 weeks in the iso week date format (some have 53, 2020/2026 for example) a method was added to set totalWeeks to 52 or 53 for the whole class. The function, which has the task to decide wether a week is the first week, in between the first week and last week or last week was also changed to adapt to these changes.