### PR TITLE
Correctly configure SMTP

### DIFF
--- a/api/config/environments/production.rb
+++ b/api/config/environments/production.rb
@@ -61,9 +61,6 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     address: ENV.fetch('SMTP_HOST', nil),
     port: ENV.fetch('SMTP_PORT', 25),
-    user_name: ENV.fetch('SMTP_USER_NAME', nil),
-    password: ENV.fetch('SMTP_PASSWORD', nil),
-    authentication: :login,
     enable_starttls_auto: true
   }
 


### PR DESCRIPTION
We don't need username or password, the ip is whitelisted on google