### PR TITLE
Update work clothing expense calculation logic and texts

### DIFF
--- a/api/app/controllers/v1/expense_sheets_controller.rb
+++ b/api/app/controllers/v1/expense_sheets_controller.rb
@@ -9,7 +9,7 @@ module V1
 
     before_action :authenticate_user!, unless: -> { request.format.pdf? }
     before_action :authenticate_from_params!, if: -> { request.format.pdf? }
-    before_action :set_expense_sheet, only: %i[show update destroy hints]
+    before_action :set_expense_sheet, only: %i[show update destroy hints live_hints]
     before_action :set_service, only: :create
     before_action :authorize_admin!, unless: -> { request.format.pdf? }
 
@@ -36,6 +36,19 @@ module V1
         I18n.t('pdfs.expense_sheet.filename', today: @expense_sheet.user.full_name),
         @expense_sheet
       )
+    end
+
+    def live_hints
+      live_expense_sheet = @expense_sheet
+      live_expense_sheet.assign_attributes expense_sheet_params
+
+      if live_expense_sheet.valid?
+        suggestions = ExpenseSheetCalculators::SuggestionsCalculator.new(live_expense_sheet).suggestions
+        remaining_days = ExpenseSheetCalculators::RemainingDaysCalculator.new(live_expense_sheet.service).remaining_days
+        render :hints, locals: { suggestions: suggestions, remaining_days: remaining_days }
+      else
+        render json: { errors: live_expense_sheet.errors }, status: :unprocessable_entity
+      end
     end
 
     def hints

--- a/api/app/services/expense_sheet_calculators/suggestions_calculator.rb
+++ b/api/app/services/expense_sheet_calculators/suggestions_calculator.rb
@@ -41,10 +41,15 @@ module ExpenseSheetCalculators
     end
 
     def suggested_clothing_expenses
-      per_day = @expense_sheet.service.service_specification.work_clothing_expenses
-      return 0 if per_day.zero?
+      per_twenty_six_days = @expense_sheet.service.service_specification.work_clothing_expenses
+      return 0 if per_twenty_six_days.zero?
 
-      max_possible_value = @expense_sheet.calculate_chargeable_days * per_day
+      already_paid_days = already_paid_clothing_expenses / per_twenty_six_days
+      to_pay_days = already_happened_work_days - already_paid_days + @expense_sheet.calculate_chargeable_days
+
+      return 0 if to_pay_days < 26
+
+      max_possible_value = (to_pay_days / 26).to_i * per_twenty_six_days
 
       difference_to_max = WORK_CLOTHING_MAX_PER_SERVICE - already_paid_clothing_expenses
       value = [max_possible_value, difference_to_max].min
@@ -58,6 +63,12 @@ module ExpenseSheetCalculators
       sheets = @expense_sheet.service.expense_sheets.before_date(@expense_sheet.beginning)
 
       sheets.sum(&:clothing_expenses)
+    end
+
+    def already_happened_work_days
+      sheets = @expense_sheet.service.expense_sheets.before_date(@expense_sheet.beginning)
+
+      sheets.sum(&:calculate_chargeable_days)
     end
 
     def day_calculator

--- a/api/app/services/expense_sheet_calculators/suggestions_calculator.rb
+++ b/api/app/services/expense_sheet_calculators/suggestions_calculator.rb
@@ -44,9 +44,6 @@ module ExpenseSheetCalculators
       per_twenty_six_days = @expense_sheet.service.service_specification.work_clothing_expenses
       return 0 if per_twenty_six_days.zero?
 
-      already_paid_days = already_paid_clothing_expenses / per_twenty_six_days
-      to_pay_days = already_happened_work_days - already_paid_days + @expense_sheet.calculate_chargeable_days
-
       return 0 if to_pay_days < 26
 
       max_possible_value = (to_pay_days / 26).to_i * per_twenty_six_days
@@ -58,6 +55,16 @@ module ExpenseSheetCalculators
     end
 
     private
+
+    def to_pay_days
+      @to_pay_days ||= calculate_to_pay_days
+    end
+
+    def calculate_to_pay_days
+      per_twenty_six_days = @expense_sheet.service.service_specification.work_clothing_expenses
+      already_paid_days = already_paid_clothing_expenses / per_twenty_six_days
+      already_happened_work_days - already_paid_days + @expense_sheet.calculate_chargeable_days
+    end
 
     def already_paid_clothing_expenses
       sheets = @expense_sheet.service.expense_sheets.before_date(@expense_sheet.beginning)

--- a/api/app/services/expense_sheet_calculators/suggestions_calculator.rb
+++ b/api/app/services/expense_sheet_calculators/suggestions_calculator.rb
@@ -19,7 +19,8 @@ module ExpenseSheetCalculators
         workfree_days: suggested_workfree_days,
         paid_company_holiday_days: suggested_paid_company_holiday_days,
         unpaid_company_holiday_days: suggested_unpaid_company_holiday_days,
-        clothing_expenses: suggested_clothing_expenses
+        clothing_expenses: suggested_clothing_expenses,
+        unpaid_clothing_expenses_days: to_pay_days
       }
     end
 
@@ -67,6 +68,10 @@ module ExpenseSheetCalculators
     end
 
     def already_paid_clothing_expenses
+      @already_paid_clothing_expenses ||= calculate_already_paid_clothing_expenses
+    end
+
+    def calculate_already_paid_clothing_expenses
       sheets = @expense_sheet.service.expense_sheets.before_date(@expense_sheet.beginning)
 
       sheets.sum(&:clothing_expenses)

--- a/api/config/locales/de.yml
+++ b/api/config/locales/de.yml
@@ -180,8 +180,8 @@ de:
           driving_expenses_comment_empty: Keine Angaben
           unpaid_vacation_comment: inkl. %{comment}
           work_clothing_expenses_comment:
-            one: CHF %{amount}/Tag für %{count} anrechenbarer Tag
-            other: CHF %{amount}/Tag für %{count} anrechenbare Tage
+            one: CHF %{amount}/26 Tage für %{count} anrechenbarer Tag
+            other: CHF %{amount}/26 Tage für %{count} anrechenbare Tage
       filename: Spesenrapport_%{today}
       header: 'Spesenrapport des Einsatzbetriebes 423 - SWO, Bahnstrasse 18b, 8603 Schwerzenbach '
       info_block:

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -180,8 +180,8 @@ en:
           driving_expenses_comment_empty: N/A
           unpaid_vacation_comment: incl. %{comment}
           work_clothing_expenses_comment:
-            one: CHF %{amount}/day for %{count} chargeable service day
-            other: CHF %{amount}/day for %{count} chargeable service days
+            one: CHF %{amount} for %{count} chargeable service day
+            other: CHF %{amount} for %{count} chargeable service days
       filename: ExpenseSheet_%{today}
       header: Expense report of the service company 423 - SWO, Bahnstrasse 18b, 8603 Schwerzenbach
       info_block:

--- a/api/config/locales/fr.yml
+++ b/api/config/locales/fr.yml
@@ -180,8 +180,8 @@ fr:
           driving_expenses_comment_empty: Aucune information
           unpaid_vacation_comment: incl. %{comment}
           work_clothing_expenses_comment:
-            one: CHF %{amount} p. jour pour %{count} jour facturable
-            other: CHF %{amount} p. jour pour %{count} jours facturables
+            one: CHF %{amount} pour %{count} jour facturable
+            other: CHF %{amount} pour %{count} jours facturables
       filename: Portrait_des_dépenses_%{today}
       header: 'Rapport des dépenses d’établissement d’affectation 423 - SWO, Bahnstrasse 18b, 8603 Schwerzenbach '
       info_block:

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     resources :payments, except: :update, param: :payment_timestamp
     resources :users, except: :create
     resources :expense_sheets do
+      post 'live_hints', on: :member
       get 'hints', on: :member
     end
 

--- a/api/spec/factories/expense_sheets.rb
+++ b/api/spec/factories/expense_sheets.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
     driving_expenses_comment { 'MyString' }
     extraordinary_expenses { 0 }
     extraordinary_expenses_comment { 'MyString' }
-    clothing_expenses { 3200 }
+    clothing_expenses { 6000 }
     clothing_expenses_comment { 'MyString' }
     bank_account_number { 'MyString' }
     state { :open }

--- a/api/spec/factories/service_specifications.rb
+++ b/api/spec/factories/service_specifications.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     name { 'MyServiceSpecification' }
     sequence(:identification_number) { |i| (82_844 + i).to_s }
     short_name { 'M' }
-    work_clothing_expenses { 230 }
+    work_clothing_expenses { 6_000 }
     accommodation_expenses { 0 }
     location { 'zurich' }
     active { true }

--- a/api/spec/requests/v1/expense_sheets_controller_spec.rb
+++ b/api/spec/requests/v1/expense_sheets_controller_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe V1::ExpenseSheetsController, type: :request do
         let(:expected_response) do
           extract_to_json(expense_sheet)
             .except(:created_at, :updated_at)
-            .merge(service_id: service.id, duration: 26, total: 81_100, deletable: true, modifiable: true)
+            .merge(service_id: service.id, duration: 26, total: 83_900, deletable: true, modifiable: true)
         end
 
         it_behaves_like 'renders a successful http status code'

--- a/api/spec/requests/v1/expense_sheets_controller_spec.rb
+++ b/api/spec/requests/v1/expense_sheets_controller_spec.rb
@@ -134,6 +134,53 @@ RSpec.describe V1::ExpenseSheetsController, type: :request do
       end
     end
 
+    describe '#live_hints' do
+      let(:service) { create :service }
+      let!(:expense_sheet) do
+        create :expense_sheet, user: service.user, beginning: service.beginning, ending: service.ending
+      end
+      let(:request) { post live_hints_v1_expense_sheet_path(expense_sheet, params: { expense_sheet: params }) }
+      let(:params) do
+        attributes_for(:expense_sheet)
+          .merge(user: service.user, beginning: service.beginning, ending: service.ending)
+      end
+
+      context 'when user is admin' do
+        subject { -> { request } }
+
+        let(:user) { create :user, :admin }
+        let(:suggestions_calculator) do
+          instance_double(ExpenseSheetCalculators::SuggestionsCalculator, suggestions: expected_suggestions)
+        end
+        let(:remaining_days_calculator) do
+          instance_double(ExpenseSheetCalculators::RemainingDaysCalculator, remaining_days: expected_remaining_days)
+        end
+        let(:expected_suggestions) { { work_days: 20 } }
+        let(:expected_remaining_days) { { sick_days: 6 } }
+
+        before do
+          allow(ExpenseSheetCalculators::SuggestionsCalculator).to receive(:new)
+            .with(expense_sheet).and_return(suggestions_calculator)
+          allow(ExpenseSheetCalculators::RemainingDaysCalculator).to receive(:new)
+            .with(service).and_return(remaining_days_calculator)
+        end
+
+        it_behaves_like 'renders a successful http status code'
+
+        it 'returns the correct hints' do
+          request
+          expect(parse_response_json(response)).to eq(
+            suggestions: expected_suggestions,
+            remaining_days: expected_remaining_days
+          )
+        end
+      end
+
+      context 'when user is not admin' do
+        it_behaves_like 'admin protected resource'
+      end
+    end
+
     describe '#hints' do
       let(:service) { create :service }
       let!(:expense_sheet) do

--- a/api/spec/requests/v1/expenses_overview_controller_spec.rb
+++ b/api/spec/requests/v1/expenses_overview_controller_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe V1::ExpensesOverviewController, type: :request do
         let(:expected_response) do
           extract_to_json(expense_sheet)
             .except(:created_at, :updated_at)
-            .merge(service_id: service.id, duration: 26, total: 81_100, deletable: true, modifiable: true)
+            .merge(service_id: service.id, duration: 26, total: 83_900, deletable: true, modifiable: true)
         end
 
         it_behaves_like 'renders a successful http status code'

--- a/api/spec/services/expense_sheet_calculators/expenses_calculator_spec.rb
+++ b/api/spec/services/expense_sheet_calculators/expenses_calculator_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe ExpenseSheetCalculators::ExpensesCalculator, type: :service do
     end
 
     describe '#calculate_full_expenses' do
-      let(:expected_values) { 71_200 }
+      let(:expected_values) { 74000 }
 
       it 'returns correct values' do
         expect(calculator.calculate_full_expenses).to eq expected_values

--- a/api/spec/services/expense_sheet_calculators/expenses_calculator_spec.rb
+++ b/api/spec/services/expense_sheet_calculators/expenses_calculator_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe ExpenseSheetCalculators::ExpensesCalculator, type: :service do
     end
 
     describe '#calculate_full_expenses' do
-      let(:expected_values) { 74000 }
+      let(:expected_values) { 74_000 }
 
       it 'returns correct values' do
         expect(calculator.calculate_full_expenses).to eq expected_values

--- a/api/spec/services/expense_sheet_calculators/suggestions_calculator_spec.rb
+++ b/api/spec/services/expense_sheet_calculators/suggestions_calculator_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe ExpenseSheetCalculators::SuggestionsCalculator, type: :service do
       {
         clothing_expenses: 6000,
         paid_company_holiday_days: 0,
+        unpaid_clothing_expenses_days: 26,
         unpaid_company_holiday_days: 0,
         work_days: 20,
         workfree_days: 6

--- a/api/spec/services/expense_sheet_calculators/suggestions_calculator_spec.rb
+++ b/api/spec/services/expense_sheet_calculators/suggestions_calculator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ExpenseSheetCalculators::SuggestionsCalculator, type: :service do
 
     let(:expected_suggestions) do
       {
-        clothing_expenses: 5980,
+        clothing_expenses: 6000,
         paid_company_holiday_days: 0,
         unpaid_company_holiday_days: 0,
         work_days: 20,
@@ -151,7 +151,7 @@ RSpec.describe ExpenseSheetCalculators::SuggestionsCalculator, type: :service do
     let(:expected_value) { daily_expenses * chargeable_days }
 
     context 'with only one expense sheet' do
-      it { is_expected.to eq 5980 }
+      it { is_expected.to eq 6000 }
     end
 
     context 'with more than one expense sheet' do
@@ -163,15 +163,15 @@ RSpec.describe ExpenseSheetCalculators::SuggestionsCalculator, type: :service do
       before do
         additional_expense_sheets = created_expense_sheets.length - 1
         created_expense_sheets.take(additional_expense_sheets).each do |expense_sheet|
-          clothing_expenses = expense_sheet.calculate_chargeable_days * daily_expenses
-          expense_sheet.update clothing_expenses: clothing_expenses
+          suggestions = ExpenseSheetCalculators::SuggestionsCalculator.new(expense_sheet).suggestions
+          expense_sheet.update clothing_expenses: suggestions[:clothing_expenses]
         end
       end
 
       context 'with enough expense_sheets to reduce clothing_expenses' do
-        let(:service_range) { get_service_range months: 4 }
+        let(:service_range) { get_service_range months: 3 }
 
-        it { is_expected.to eq 3300 }
+        it { is_expected.to eq 6000 }
       end
 
       context 'with enough expense_sheets to nullify clothing_expenses' do

--- a/api/spec/services/pdfs/expense_sheet/generator_service_spec.rb
+++ b/api/spec/services/pdfs/expense_sheet/generator_service_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe Pdfs::ExpenseSheet::GeneratorService, type: :service do
           '0', 'Urlaubstage', '0.00', '0.00', '0.00', '0.00', '0.00', '0.00',
           'inkl. MyString',
           '+', 'Fahrspesen', 'MyString', '20.00',
-          '+', 'Arbeitskleider', 'CHF 2.30/Tag für 27 anrechenbare Tage', '32.00',
-          'Gesamt:', '818.00',
+          '+', 'Arbeitskleider', 'CHF 60.00/26 Tage für 27 anrechenbare Tage', '60.00',
+          'Gesamt:', '846.00',
           'Bankverbindung:', 'CH93 0076 2011 6238 5295 7',
           'Konto-Nr.::', '4470 (200)'
         ]
@@ -76,10 +76,10 @@ RSpec.describe Pdfs::ExpenseSheet::GeneratorService, type: :service do
 
       context 'when work_clothing_expenses is more than threshold' do
         let(:service_specification) do
-          create(:service_specification, identification_number: 82_846, work_clothing_expenses: 1000)
+          create(:service_specification, identification_number: 82_846, work_clothing_expenses: 6000)
         end
 
-        let(:expected_texts) { ['CHF 10.00/Tag für 27 anrechenbare Tage', '32.00'] }
+        let(:expected_texts) { ['CHF 60.00/26 Tage für 27 anrechenbare Tage', '60.00'] }
 
         it 'renders correct text' do
           expect(pdf_text_inspector.strings[-8..-7]).to eq expected_texts

--- a/frontend/src/locales/messages.de.json
+++ b/frontend/src/locales/messages.de.json
@@ -172,7 +172,7 @@
   "views.expense_sheets.absolvedDaysBreakdownSegment.work_days_sugestion": "Vorschlag: {workDaysSuggestion} Tage",
   "views.expense_sheets.absolvedDaysBreakdownSegment.worked": "Gearbeitet",
   "views.expense_sheets.absolvedDaysBreakdownSegment.workfree": "Arbeitsfrei",
-  "views.expense_sheets.ClothingExpensesSegment.hint_clothin_expenses": "Vorschlag: {hintClothingExpenses}",
+  "views.expense_sheets.ClothingExpensesSegment.hint_clothing_expenses": "Vorschlag: {hintClothingExpenses} ({hintUnpaidClothingExpenseDays} Tage)",
   "views.expense_sheets.CompanyHolidaysSegment.paid_company_holidays": "Vorschlag: {paidCompanyHolidays} Tage",
   "views.expense_sheets.CompanyHolidaysSegment.unpaid_company_holidays": "Vorschlag: {unpaidCompanyHolidays} Tage",
   "views.expense_sheets.DrivingExpensesSegment.driving_expenses": "Fahrspesen",

--- a/frontend/src/locales/messages.en.json
+++ b/frontend/src/locales/messages.en.json
@@ -170,7 +170,7 @@
   "views.expense_sheets.absolvedDaysBreakdownSegment.work_days_sugestion": "Default: {workDaysSuggestion} Days",
   "views.expense_sheets.absolvedDaysBreakdownSegment.worked": "Worked",
   "views.expense_sheets.absolvedDaysBreakdownSegment.workfree": "Free of work",
-  "views.expense_sheets.ClothingExpensesSegment.hint_clothin_expenses": "Proposal: {hintClothingExpenses}",
+  "views.expense_sheets.ClothingExpensesSegment.hint_clothing_expenses": "Proposal: {hintClothingExpenses} ({hintUnpaidClothingExpenseDays} Days)",
   "views.expense_sheets.CompanyHolidaysSegment.paid_company_holidays": "Proposal: {paidCompanyHolidays} Days",
   "views.expense_sheets.CompanyHolidaysSegment.unpaid_company_holidays": "Proposal: {unpaidCompanyHolidays} Days",
   "views.expense_sheets.DrivingExpensesSegment.driving_expenses": "Travel expenses",

--- a/frontend/src/locales/messages.fr.json
+++ b/frontend/src/locales/messages.fr.json
@@ -173,7 +173,7 @@
   "views.expense_sheets.absolvedDaysBreakdownSegment.work_days_sugestion": "Valeur par défaut : {workDaysSuggestion} Jours",
   "views.expense_sheets.absolvedDaysBreakdownSegment.worked": "A travaillé",
   "views.expense_sheets.absolvedDaysBreakdownSegment.workfree": "Libre de travail",
-  "views.expense_sheets.ClothingExpensesSegment.hint_clothin_expenses": "Proposition : {hintClothingExpenses}",
+  "views.expense_sheets.ClothingExpensesSegment.hint_clothing_expenses": "Proposition : {hintClothingExpenses} ({hintUnpaidClothingExpenseDays} Jours)",
   "views.expense_sheets.CompanyHolidaysSegment.paid_company_holidays": "Proposition : {paidCompanyHolidays} Jours",
   "views.expense_sheets.CompanyHolidaysSegment.unpaid_company_holidays": "Proposition : {unpaidCompanyHolidays} Jours",
   "views.expense_sheets.DrivingExpensesSegment.driving_expenses": "Frais de voyage",

--- a/frontend/src/stores/expenseSheetStore.ts
+++ b/frontend/src/stores/expenseSheetStore.ts
@@ -1,6 +1,6 @@
 // tslint:disable:no-console
 import * as _ from 'lodash';
-import { action, computed, observable } from 'mobx';
+import {action, computed, observable, runInAction} from 'mobx';
 import { ExpenseSheet, ExpenseSheetHints, ExpenseSheetListing, ExpenseSheetState, SickDaysDime } from '../types';
 import { stateTranslation } from '../utilities/helpers';
 import { DomainStore } from './domainStore';
@@ -53,6 +53,7 @@ export class ExpenseSheetStore extends DomainStore<ExpenseSheet, ExpenseSheetLis
   @observable
   totalSum: string;
 
+  @observable
   hints?: ExpenseSheetHints;
 
   @observable
@@ -133,6 +134,30 @@ export class ExpenseSheetStore extends DomainStore<ExpenseSheet, ExpenseSheetLis
       const response = await this.mainStore.api.get<ExpenseSheetHints>(`/expense_sheets/${expenseSheetId}/hints`);
       this.hints = response.data;
     } catch (e) {
+      this.mainStore.displayError(
+        this.mainStore.intl.formatMessage(
+          {
+            id: 'store.expenseSheetStore.expense_hints_not_loaded',
+            defaultMessage: 'Spesenvorschläge konnten nicht geladen werden',
+          },
+        ));
+      console.error(e);
+      throw e;
+    }
+  }
+
+  @action
+  async fetchLiveHints(expenseSheet: ExpenseSheet) {
+    try {
+      const response = await this.mainStore.api.post<ExpenseSheetHints>(`/expense_sheets/${expenseSheet.id}/live_hints`, { expense_sheet: expenseSheet });
+      runInAction(() => {
+        this.hints = response.data;
+      });
+    } catch (e) {
+      if (e.error.response.status === 422) {
+        return;
+      }
+
       this.mainStore.displayError(
         this.mainStore.intl.formatMessage(
           {

--- a/frontend/src/stores/expenseSheetStore.ts
+++ b/frontend/src/stores/expenseSheetStore.ts
@@ -1,6 +1,6 @@
 // tslint:disable:no-console
 import * as _ from 'lodash';
-import {action, computed, observable, runInAction} from 'mobx';
+import { action, computed, observable, runInAction } from 'mobx';
 import { ExpenseSheet, ExpenseSheetHints, ExpenseSheetListing, ExpenseSheetState, SickDaysDime } from '../types';
 import { stateTranslation } from '../utilities/helpers';
 import { DomainStore } from './domainStore';
@@ -149,7 +149,9 @@ export class ExpenseSheetStore extends DomainStore<ExpenseSheet, ExpenseSheetLis
   @action
   async fetchLiveHints(expenseSheet: ExpenseSheet) {
     try {
-      const response = await this.mainStore.api.post<ExpenseSheetHints>(`/expense_sheets/${expenseSheet.id}/live_hints`, { expense_sheet: expenseSheet });
+      const response = await this.mainStore.api.post<ExpenseSheetHints>(
+        `/expense_sheets/${expenseSheet.id}/live_hints`, { expense_sheet: expenseSheet }
+      );
       runInAction(() => {
         this.hints = response.data;
       });

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -76,6 +76,7 @@ export interface ExpenseSheetHints {
     paid_company_holiday_days: number;
     unpaid_company_holiday_days: number;
     clothing_expenses: number;
+    unpaid_clothing_expenses_days: number;
   };
   remaining_days: {
     sick_days: number;

--- a/frontend/src/views/expense_sheets/expense_sheet_form/ExpenseSheetForm.tsx
+++ b/frontend/src/views/expense_sheets/expense_sheet_form/ExpenseSheetForm.tsx
@@ -1,4 +1,5 @@
 import { FormikProps } from 'formik';
+import debounce from 'lodash.debounce';
 import { inject, observer } from 'mobx-react';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
@@ -32,13 +33,29 @@ interface ExpenseSheetFormState {
 @inject('mainStore', 'expenseSheetStore', 'serviceSpecificationStore')
 @observer
 class ExpenseSheetFormInner extends React.Component<Props, ExpenseSheetFormState> {
+  private previousValues: any = null;
+
   constructor(props: Props) {
     super(props);
     this.state = {
       safeOverride: false,
     };
-
   }
+
+  private debouncedApiCall = debounce(async (values: ExpenseSheet) => {
+    await this.props.expenseSheetStore!.fetchLiveHints(values)
+  }, 500);
+
+  componentWillUnmount() {
+    this.debouncedApiCall.cancel();
+  }
+
+  private handleValuesChange = (prevValues: any, nextValues: any) => {
+    if (prevValues === nextValues) {
+      return;
+    }
+    this.debouncedApiCall(nextValues);
+  };
 
   render() {
     const {
@@ -58,43 +75,50 @@ class ExpenseSheetFormInner extends React.Component<Props, ExpenseSheetFormState
         onSubmit={(formValues: FormValues) => onSubmit({ ...formValues })}
         title={title}
         validationSchema={expenseSheetSchema}
-        render={(formikProps: FormikProps<{}>): React.ReactNode => (
-          <Form>
-            <ExpenseSheetFormHeader
-              service={service}
-              expenseSheetState={expenseSheet.state}
-              serviceSpecification={serviceSpecification}
-            />
+        render={(formikProps: FormikProps<{}>): React.ReactNode => {
+          if (this.previousValues !== JSON.stringify(formikProps.values)) {
+            this.previousValues = JSON.stringify(formikProps.values);
+            this.handleValuesChange(formikProps.initialValues, formikProps.values);
+          }
 
-            <FormSegments.GeneralSegment service={service} mainStore={mainStore!}/>
-            <FormSegments.AbsolvedDaysBreakdownSegment
-              hints={hints}
-              mainStore={mainStore!}
-              sickDays={sickDays}
-              buttonDeactive={buttonDeactive}
-              onSaveSickDays={
-              (value) => this.saveSickDaysFromDime(formikProps, value)}
-            />
-            <FormSegments.CompanyHolidaysSegment hints={hints} mainStore={mainStore!}/>
-            <FormSegments.PaidVacationSegment mainStore={mainStore!}/>
-            <FormSegments.UnpaidVacationSegment mainStore={mainStore!}/>
-            <FormSegments.ClothingExpensesSegment hints={hints} mainStore={mainStore!}/>
-            <FormSegments.DrivingExpensesSegment mainStore={mainStore!}/>
-            <FormSegments.ExtraordinaryExpensesSegment mainStore={mainStore!}/>
-            <FormSegments.FooterSegment mainStore={mainStore!}/>
-            <FormSegments.StateSegment expenseSheetState={expenseSheet.state} expenseSheetStore={expenseSheetStore!}/>
+          return (
+            <Form>
+              <ExpenseSheetFormHeader
+                service={service}
+                expenseSheetState={expenseSheet.state}
+                serviceSpecification={serviceSpecification}
+              />
 
-            <ExpenseSheetFormButtons
-              safeOverride={this.state.safeOverride}
-              onForceSave={() => this.onForceSaveButtonClicked(formikProps)}
-              onSave={() => this.onSaveButtonClicked(formikProps)}
-              onDelete={this.onDeleteButtonClicked.bind(this)}
-              expenseSheet={expenseSheet}
-              mainStore={mainStore!}
-              service={service}
-            />
-          </Form>
-        )}
+              <FormSegments.GeneralSegment service={service} mainStore={mainStore!}/>
+              <FormSegments.AbsolvedDaysBreakdownSegment
+                hints={hints}
+                mainStore={mainStore!}
+                sickDays={sickDays}
+                buttonDeactive={buttonDeactive}
+                onSaveSickDays={
+                (value) => this.saveSickDaysFromDime(formikProps, value)}
+              />
+              <FormSegments.CompanyHolidaysSegment hints={hints} mainStore={mainStore!}/>
+              <FormSegments.PaidVacationSegment mainStore={mainStore!}/>
+              <FormSegments.UnpaidVacationSegment mainStore={mainStore!}/>
+              <FormSegments.ClothingExpensesSegment hints={hints} mainStore={mainStore!}/>
+              <FormSegments.DrivingExpensesSegment mainStore={mainStore!}/>
+              <FormSegments.ExtraordinaryExpensesSegment mainStore={mainStore!}/>
+              <FormSegments.FooterSegment mainStore={mainStore!}/>
+              <FormSegments.StateSegment expenseSheetState={expenseSheet.state} expenseSheetStore={expenseSheetStore!}/>
+
+              <ExpenseSheetFormButtons
+                safeOverride={this.state.safeOverride}
+                onForceSave={() => this.onForceSaveButtonClicked(formikProps)}
+                onSave={() => this.onSaveButtonClicked(formikProps)}
+                onDelete={this.onDeleteButtonClicked.bind(this)}
+                expenseSheet={expenseSheet}
+                mainStore={mainStore!}
+                service={service}
+              />
+            </Form>
+          );
+        }}
       />
     );
   }

--- a/frontend/src/views/expense_sheets/expense_sheet_form/segments/ClothingExpensesSegment.tsx
+++ b/frontend/src/views/expense_sheets/expense_sheet_form/segments/ClothingExpensesSegment.tsx
@@ -12,9 +12,12 @@ export const ClothingExpensesSegment = expenseSheetFormSegment(
         horizontal
         appendedLabels={[
           mainStore.intl.formatMessage({
-            id: 'views.expense_sheets.ClothingExpensesSegment.hint_clothin_expenses',
-            defaultMessage: 'Vorschlag: {hintClothingExpenses}',
-          }, { hintClothingExpenses: mainStore!.formatCurrency(hints.suggestions.clothing_expenses) },
+            id: 'views.expense_sheets.ClothingExpensesSegment.hint_clothing_expenses',
+            defaultMessage: 'Vorschlag: {hintClothingExpenses} ({hintUnpaidClothingExpenseDays} Tage)',
+          }, {
+            hintClothingExpenses: mainStore!.formatCurrency(hints.suggestions.clothing_expenses),
+            hintUnpaidClothingExpenseDays: hints.suggestions.unpaid_clothing_expenses_days,
+          },
         )]}
         component={CurrencyField}
         name={'clothing_expenses'}


### PR DESCRIPTION
This also adds a WIP/beta live_hints to the expense form

Changed work clothing expense calculations to be based on 26-day cycles instead of daily rates. Adjusted factories, specs, localized texts, and related logic to align with the new calculation model. This ensures consistent and accurate handling of clothing expenses across the system.

Mantis 230