### PR TITLE
Add integration test harness (Rails upgrade step 1)

### DIFF
--- a/RAILS_UPGRADE_PROCESS.md
+++ b/RAILS_UPGRADE_PROCESS.md
@@ -1,0 +1,152 @@
+# Rails Major Version Upgrade Process
+
+A repeatable process for upgrading a Rails API app across multiple major versions (e.g. Rails 6 → 8, Ruby 2.7 → 3.4).
+
+---
+
+## 1. Write an integration test harness first
+
+Before touching any gem or config, write a suite of end-to-end integration tests against the running API. These are your safety net for the entire upgrade — if they pass at the end, the upgrade didn't break user-visible behavior.
+
+Use a language independent of the app (TypeScript/Jest works well for a Rails API) so the test runner is unaffected by Ruby or Rails changes. Cover:
+
+- Every major resource: CRUD operations, authentication, edge cases
+- Any business-critical exports or report endpoints (PDFs, XLSX, etc.)
+- Error cases (unauthorized, validation failures, missing records)
+
+Run these against the **current** app first and get them all green. Commit them. They are now the contract you must not break.
+
+The integration tests also expose gaps in your existing behavior — undocumented response shapes, implicit assumptions about status codes — that are better discovered now than mid-upgrade.
+
+---
+
+## 2. Audit before touching Rails
+
+Before changing a line of code, document the current state:
+
+- Ruby version, Rails version, all gem versions
+- Test suite pass rate and coverage percentage
+- Which parts of the codebase have zero or weak coverage
+- Which gems are likely to have breaking changes (auth, serialization, background jobs, pagination, soft-delete)
+- CI pipeline assumptions (Ruby version in Dockerfile, CI config, database version)
+
+Write this down. You will reference it constantly.
+
+---
+
+## 3. Upgrade Rails incrementally — one major version at a time
+
+Never jump directly from Rails 6.0 to 8.0. Step through each major version:
+
+```
+6.0 → 6.1 → 7.0 → 7.1 → 8.0
+```
+
+For each step:
+
+1. Update the `rails` gem version in Gemfile
+2. Run `bundle update rails` (plus closely coupled gems like `activerecord`, `actionpack`)
+3. Run `bin/rails app:update` to get new initializers, config defaults, and framework defaults — review every change
+4. Run the test suite. Fix failures before moving to the next version.
+5. Commit the working state at each version before proceeding
+
+The framework itself ships a migration guide for each version pair. Read it. The defaults that change between versions are often the source of subtle runtime breakage.
+
+---
+
+## 4. Upgrade Ruby separately from Rails
+
+Upgrading Ruby and Rails at the same time makes it hard to attribute failures. Prefer:
+
+- Upgrade Rails to the target version first (still on old Ruby if compatible)
+- Then bump Ruby
+- Or: upgrade Ruby first, fix Ruby-level breakage, then upgrade Rails
+
+The biggest Ruby 2 → 3 breaking change is **keyword argument separation**. Methods that accepted `**options` as a positional hash now require explicit keyword syntax at call sites. The interpreter error messages are clear; the fix is mechanical.
+
+---
+
+## 5. Resolve gem compatibility
+
+After bumping Rails and Ruby, many gems will either fail to install or install but behave differently. Triage order:
+
+1. **Hard blockers** — gems that won't install at all (incompatible version constraints). Update or replace them.
+2. **Silent behavior changes** — gems that install but changed their API (read changelogs between your old and new pinned version).
+3. **Soft-delete, serialization, and auth gems** are historically the riskiest here. Test them explicitly.
+
+Pin gems that are not yet compatible to an older version and file a ticket to revisit later. Don't let one incompatible gem block the whole upgrade.
+
+---
+
+## 6. Fix the test suite
+
+After the upgrade, the test suite will have failures. Work through them in priority order:
+
+1. **Factory/fixture failures** — often caused by changed validations or renamed columns
+2. **Controller spec failures** — Rails 8 changed parameter handling (`params.require` behavior), response codes, and some middleware defaults
+3. **Model spec failures** — scope changes, validation changes, enum syntax changes (Rails 7+ uses keyword syntax)
+4. **Service/integration failures** — usually logic that relied on implicit behavior that changed
+
+Do not use unsafe autocorrect (`rubocop -A`) during this phase. It will silently change `params.require(:x)` to `params.expect(:x)` and break working tests without obvious errors.
+
+Get to green before moving on.
+
+---
+
+## 7. Fix linting
+
+RuboCop and its extension gems (rubocop-rails, rubocop-rspec, rubocop-performance) ship new cops with major releases. After upgrading them:
+
+1. Run `bundle exec rubocop` on the **entire codebase**, not just changed files
+2. Apply only **safe autocorrect** (`--autocorrect`, not `-A`)
+3. Regenerate `rubocop_todo.yml` with `--auto-gen-config --auto-gen-only-exclude --exclude-limit 1000 --no-offense-counts`
+4. After regenerating, check that any glob patterns you relied on (`spec/services/**/*`) were not replaced with individual file lists — the generator does this and it makes the todo brittle
+
+Run the full linter before every push. CI will check everything; local spot-checks will not catch it.
+
+---
+
+## 8. Improve test coverage
+
+The upgrade is a good forcing function to close coverage gaps that accumulated over time:
+
+- Identify untested services (often the worst offenders — zero specs, hidden behind `:nocov:` tags)
+- Write unit specs for each service, testing all public methods and meaningful edge cases
+- Remove `:nocov:` tags from code that is now tested
+- Fill in empty controller spec stubs (index, show, create, update, destroy, unauthorized)
+- Add missing model specs (associations, validations)
+
+Measure before and after. A 5–10 point coverage gain is achievable in a single pass.
+
+---
+
+## 9. Update Docker and CI
+
+- Bump the base image (e.g. `ruby:3.4`)
+- If you added a non-root user for security, `chown` the app directory **before** switching to that user — otherwise Rails can't write to `tmp/` or `log/` at runtime
+- Update database versions in docker-compose (MySQL 5.7 → 8.x, Postgres 14 → 16, etc.)
+- Update `actions/checkout` and other GitHub Actions to current versions
+- Rename or update CI compose files if they reference old service names
+
+---
+
+## 10. PR review cycle
+
+Open the PR early (draft if needed) to get CI running. Expect multiple rounds:
+
+- First CI run reveals linting failures you missed locally
+- Code review (automated or human) finds gaps in test assertions, missing guards, Docker issues
+- Reply to every comment — either "fixed in commit X" or a clear reason why it's out of scope
+- Keep the branch rebased or at least conflict-free against the target branch
+
+---
+
+## Key lessons
+
+- **Run linting on the full codebase before every push.** Not just changed files. The entire thing.
+- **Never use unsafe autocorrect (`-A`) during an active upgrade.** It changes semantics, not just style.
+- **Step through major versions one at a time** and commit a passing state at each step.
+- **Read gem changelogs** between your pinned versions, especially for auth, serialization, and soft-delete gems.
+- **Write integration tests before the first gem bump** — they are your contract, not your afterthought.
+- **Test coverage gaps become visible during upgrades** — take the opportunity to close them.
+- **Docker non-root users need explicit `chown`** after `COPY` and before `USER`.

--- a/RAILS_UPGRADE_PROCESS.md
+++ b/RAILS_UPGRADE_PROCESS.md
@@ -38,7 +38,7 @@ Write this down. You will reference it constantly.
 
 Never jump directly from Rails 6.0 to 8.0. Step through each major version:
 
-```
+```text
 6.0 → 6.1 → 7.0 → 7.1 → 8.0
 ```
 

--- a/api/db/seed_data/services.rb
+++ b/api/db/seed_data/services.rb
@@ -3,43 +3,45 @@
 beginning = Time.zone.today.at_beginning_of_week - 4.weeks
 beginning2 = Time.zone.today.at_beginning_of_week + 1.week
 
+service_attributes = [
+  {
+    user: User.find_by(email: 'zivi@example.com'),
+    service_specification: ServiceSpecification.first,
+    beginning: beginning,
+    ending: beginning + 25.days,
+    confirmation_date: beginning - 1.month,
+    service_type: :normal,
+    first_swo_service: true,
+    long_service: false,
+    probation_service: false,
+    feedback_mail_sent: false
+  },
+  {
+    user: User.find_by(email: 'zivi_francise@france.ch'),
+    service_specification: ServiceSpecification.last,
+    beginning: (Time.zone.today - 180.days).at_beginning_of_week,
+    ending: Time.zone.today.at_end_of_week - 2.days,
+    confirmation_date: beginning - 8.months,
+    service_type: :normal,
+    first_swo_service: false,
+    long_service: true,
+    probation_service: false,
+    feedback_mail_sent: false
+  },
+  {
+    user: User.find_by(email: 'zivi_francise@france.ch'),
+    service_specification: ServiceSpecification.last,
+    beginning: beginning2,
+    ending: beginning2 + 3.weeks + 4.days,
+    confirmation_date: beginning2 - 1.month,
+    service_type: :normal,
+    first_swo_service: false,
+    long_service: false,
+    probation_service: false,
+    feedback_mail_sent: false
+  }
+]
+
 Service.create!(
-  [
-    {
-      user: User.find_by(email: 'zivi@example.com'),
-      service_specification: ServiceSpecification.first,
-      beginning: beginning,
-      ending: beginning + 25.days,
-      confirmation_date: beginning - 1.month,
-      service_type: :normal,
-      first_swo_service: true,
-      long_service: false,
-      probation_service: false,
-      feedback_mail_sent: false
-    },
-    {
-      user: User.find_by(email: 'zivi_francise@france.ch'),
-      service_specification: ServiceSpecification.last,
-      beginning: (Time.zone.today - 180.days).at_beginning_of_week,
-      ending: Time.zone.today.at_end_of_week - 2.days,
-      confirmation_date: beginning - 8.months,
-      service_type: :normal,
-      first_swo_service: false,
-      long_service: true,
-      probation_service: false,
-      feedback_mail_sent: false
-    },
-    {
-      user: User.find_by(email: 'zivi_francise@france.ch'),
-      service_specification: ServiceSpecification.last,
-      beginning: beginning2,
-      ending: beginning2 + 3.weeks + 4.days,
-      confirmation_date: beginning2 - 1.month,
-      service_type: :normal,
-      first_swo_service: false,
-      long_service: false,
-      probation_service: false,
-      feedback_mail_sent: false
-    }
-  ]
+  service_attributes.map { |attrs| attrs.merge(service_days: Service.new(attrs).calculate_service_days) }
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
             - USERNAME_DIME=zivi@example.com
             - PASSWORD_DIME=123456
             - CONNECT_TO_DIME=false
-            - API_URI_DIME=https://dime-apir-develop.stiftungswo.ch
+            - API_URI_DIME=${API_URI_DIME:-https://dime-apir-develop.stiftungswo.ch}
             - REDIS_URL=redis://redis:6379/0
 
     worker:

--- a/integration-tests/.gitignore
+++ b/integration-tests/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,139 @@
+# Integration tests
+
+Black-box HTTP tests for the Better-iZivi Rails API, written in TypeScript so
+they are unaffected by the Ruby/Rails upgrade they exist to guard (see
+`RailsUpgradeProcess.md`, step 1). They hit a running instance of the API
+over the network and assert on status codes and response shapes — they know
+nothing about the Ruby process behind the API.
+
+## Running
+
+1. Start the API against a database with the schema loaded:
+
+   ```
+   docker compose up -d mysql api
+   docker exec better_izivi_api bin/rails db:create db:schema:load
+   ```
+
+   `rails db:seed` is **not** required and does not need to have run
+   (though it's harmless if it has — see below).
+
+2. Install dependencies and run the suite:
+
+   ```
+   npm install
+   npm test
+   ```
+
+   By default the suite targets the API at `http://localhost:28000` and
+   MySQL at `localhost:23306` (root, no password, `better_izivi_development`)
+   — the ports/credentials `docker-compose.yml` exposes. Override with
+   `API_BASE_URL` / `TEST_DB_HOST` / `TEST_DB_PORT` / `TEST_DB_USER` /
+   `TEST_DB_PASSWORD` / `TEST_DB_NAME` if needed.
+
+## Why this doesn't rely on `rails db:seed`
+
+A Jest `globalSetup` (`globalSetup.js`) connects to MySQL directly and
+inserts, over raw SQL, the one thing the API has no endpoint to create (a
+`RegionalCenter`) and the one privileged account self-registration can never
+produce (an admin user). This is deliberate: `rails db:seed` is Ruby
+application code that goes through the same models, validations and gems
+this suite exists to protect against regressions in. It has already broken
+silently once on `develop` — see the `service_days` seed fix in this branch,
+which nobody noticed because nothing exercises `db:seed` in CI or in specs
+(RSpec uses factories, not seeds). If seeding breaks again mid-upgrade, this
+suite should still be able to stand itself up, using only the schema and a
+running server.
+
+Every other fixture (civil servants, service specifications, services,
+expense sheets, holidays) is created by the tests themselves through the API
+under test, following the same self-registration / admin-create flows a real
+client would use.
+
+## Route coverage
+
+Every `rails routes` entry that's part of the actual API surface is
+exercised, cross-checked route by route against `bin/rails routes` — including
+both self-service Devise paths (`/v1/users/sign_in`, `/sign_out`, `/password`,
+`/validate`, and the bare `/v1/users` collection route for
+`registrations#update` / `#destroy`, which is a separate code path from the
+admin-facing `/v1/users/:id`) and every domain resource's index/show/create/
+update/destroy, PDF/XML exports, and calculator endpoints.
+
+One thing is out of scope, not overlooked: Sidekiq's mounted web UI and the
+default Rails ActiveStorage routes are Rails/gem scaffolding, not application
+code — grepping the codebase for `has_one_attached` / `has_many_attached`
+turns up nothing, confirming ActiveStorage isn't actually used by this
+domain.
+
+Everything else, including `GET /v1/expenses_sheet_sick_days_dime`, is
+covered — see below for how that one works.
+
+## Testing the DIME integration for real
+
+`expenses_sheet_sick_days_dime` calls out to an external service (DIME) via
+`AuthenticateInDime`, which hardcodes `use_ssl = true` and
+`verify_mode = OpenSSL::SSL::VERIFY_PEER`. The real `API_URI_DIME` staging
+host isn't reachable from here, so `dimeSickDays.test.ts` stands up its own
+mock instead of skipping the endpoint:
+
+1. `src/dimeMock.ts` generates a throwaway self-signed cert (`openssl req`)
+   and starts a local HTTPS server implementing the three DIME endpoints
+   `AuthenticateInDime` calls (`/v2/employees/sign_in`, `/v2/employees`
+   search, `/v2/project_efforts`), recording every request it receives.
+2. `src/dockerDime.ts` recreates the `api` container (`docker compose up -d
+   --force-recreate api`) with `API_URI_DIME` pointed at the mock via the
+   docker-compose bridge network's gateway IP (`172.20.0.1`, reachable from
+   inside the container as "the host"), then installs the mock's cert into
+   the container's trust store (`docker exec -u root ... update-ca-certificates`)
+   so the hardcoded `VERIFY_PEER` check passes.
+3. Tests hit `/v1/expenses_sheet_sick_days_dime` for real and assert both the
+   response *and* that the mock actually received the expected requests
+   (the user's email in the search filter, the expense sheet's own date
+   range — not the parent service's — in the project-efforts query).
+4. `afterAll` always recreates the `api` container again with no override,
+   restoring the real `API_URI_DIME` default from `docker-compose.yml`,
+   before the next test file runs.
+
+This required one small, backwards-compatible change to `docker-compose.yml`:
+`API_URI_DIME` is now `${API_URI_DIME:-https://dime-apir-develop.stiftungswo.ch}`
+instead of a hardcoded literal, so it can be overridden per-invocation without
+touching the file again. Nothing changes for anyone who doesn't set that
+env var.
+
+Because this test file recreates a shared container twice, it needs the
+`docker` CLI and `openssl` on whatever machine runs the suite, plus
+permission to `docker exec -u root` into the `api` container. If it's
+interrupted mid-run (e.g. `Ctrl-C`), the `api` container may be left pointed
+at the (by-then-stopped) mock — rerun `docker compose up -d --force-recreate
+api` to restore it.
+
+## Notes
+
+- Tests that need a "regular user" register a brand-new civil servant per
+  test via the public registration endpoint, so nothing here mutates shared
+  state other tests depend on. The suite doesn't need to run against a
+  freshly wiped database between runs, but a persistent database will
+  accumulate the users/services/holidays each run creates.
+- A couple of tests are written against, and comment on, existing quirks in
+  the API (e.g. `HolidaysController` has no admin restriction;
+  `PaymentsController#create` returns `200` instead of `201` due to a
+  `render state: :created` typo). These are captured as the current
+  contract, not asserted as correct — the goal of this suite is to catch
+  behavior changes during the Rails upgrade, not to fix pre-existing bugs.
+- `ExpenseSheetCalculators::SuggestionsCalculator#calculate_to_pay_days`
+  divides by a service specification's `work_clothing_expenses` without a
+  zero guard (unlike its sibling method a few lines below, which has one) —
+  it 500s on `/hints` if that field is `0`. `fixtures.ts` sets it to a
+  non-zero value for exactly this reason.
+- `Payment#payment_timestamp` is floored to the whole second and is the only
+  thing a payment is grouped/keyed by, so two `POST /v1/payments` calls
+  landing in the same wall-clock second collide into one payment.
+  `payments.test.ts` waits for a fresh second before each one — this suite
+  runs fast enough for the collision to happen for real, not just in theory.
+- The password-reset test reads the token out of the email `letter_opener`
+  (this dev environment's `ActionMailer` delivery method) writes to
+  `api/tmp/letter_opener/<id>/rich.html` — see `src/mail.ts`. Devise only
+  ever stores a digest of the token in the DB, so the delivered email is the
+  only place the raw value appears. `docker-compose.yml` bind-mounts `./api`
+  into the container, so this directory is also readable from the host.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -10,7 +10,7 @@ nothing about the Ruby process behind the API.
 
 1. Start the API against a database with the schema loaded:
 
-   ```
+   ```sh
    docker compose up -d mysql api
    docker exec better_izivi_api bin/rails db:create db:schema:load
    ```
@@ -20,7 +20,7 @@ nothing about the Ruby process behind the API.
 
 2. Install dependencies and run the suite:
 
-   ```
+   ```sh
    npm install
    npm test
    ```
@@ -83,9 +83,11 @@ mock instead of skipping the endpoint:
    search, `/v2/project_efforts`), recording every request it receives.
 2. `src/dockerDime.ts` recreates the `api` container (`docker compose up -d
    --force-recreate api`) with `API_URI_DIME` pointed at the mock via the
-   docker-compose bridge network's gateway IP (`172.20.0.1`, reachable from
-   inside the container as "the host"), then installs the mock's cert into
-   the container's trust store (`docker exec -u root ... update-ca-certificates`)
+   docker-compose bridge network's gateway IP (read off the running container
+   with `docker inspect`, since docker-compose.yml doesn't pin a subnet and
+   Docker may assign a different one per machine — reachable from inside the
+   container as "the host"), then installs the mock's cert into the
+   container's trust store (`docker exec -u root ... update-ca-certificates`)
    so the hardcoded `VERIFY_PEER` check passes.
 3. Tests hit `/v1/expenses_sheet_sick_days_dime` for real and assert both the
    response *and* that the mock actually received the expected requests

--- a/integration-tests/globalSetup.js
+++ b/integration-tests/globalSetup.js
@@ -1,0 +1,98 @@
+const mysql = require('mysql2/promise');
+const bcrypt = require('bcryptjs');
+
+const DB_HOST = process.env.TEST_DB_HOST || 'localhost';
+const DB_PORT = Number(process.env.TEST_DB_PORT || 23306);
+const DB_USER = process.env.TEST_DB_USER || 'root';
+const DB_PASSWORD = process.env.TEST_DB_PASSWORD || '';
+const DB_NAME = process.env.TEST_DB_NAME || 'better_izivi_development';
+
+// Devise's default `stretches` (bcrypt cost) outside the test environment.
+// This app's initializer doesn't override it, so it applies to the
+// development database this suite runs against.
+const BCRYPT_COST = 12;
+
+const REGIONAL_CENTER_SHORT_NAME = 'IT-Bootstrap';
+const ADMIN_EMAIL = 'integration-test-admin@example.com';
+const ADMIN_PASSWORD = 'password123';
+const ADMIN_ZDP = 900001;
+
+/**
+ * Bootstraps the two fixtures the API itself has no way to create and every
+ * other test in this suite needs transitively: a RegionalCenter (no create
+ * endpoint exists, but User#regional_center_id is a required FK) and one
+ * admin user (self-registration can never produce an admin).
+ *
+ * This talks to MySQL directly instead of going through `rails db:seed` /
+ * ActiveRecord on purpose: seeding is Ruby application code, so it can be
+ * broken by exactly the kind of mid-upgrade regression this suite exists to
+ * catch (see api/db/seed_data/services.rb, which was broken on `develop` by
+ * an unrelated model change and nobody noticed because nothing exercised
+ * `db:seed`). This bootstrap only depends on the DB schema being loaded, so
+ * it keeps working even while the Rails app itself is mid-breakage.
+ */
+module.exports = async function globalSetup() {
+  const connection = await mysql.createConnection({
+    host: DB_HOST,
+    port: DB_PORT,
+    user: DB_USER,
+    password: DB_PASSWORD,
+    database: DB_NAME,
+  });
+
+  try {
+    const regionalCenterId = await ensureRegionalCenter(connection);
+    await ensureAdminUser(connection, regionalCenterId);
+  } finally {
+    await connection.end();
+  }
+};
+
+async function ensureRegionalCenter(connection) {
+  const [existing] = await connection.execute('SELECT id FROM regional_centers WHERE short_name = ?', [
+    REGIONAL_CENTER_SHORT_NAME,
+  ]);
+  if (existing.length > 0) {
+    return existing[0].id;
+  }
+
+  const [result] = await connection.execute(
+    'INSERT INTO regional_centers (name, address, short_name, created_at, updated_at) VALUES (?, ?, ?, NOW(), NOW())',
+    ['Integration Test Regional Center', 'Bootstrapped by integration-tests/globalSetup.js', REGIONAL_CENTER_SHORT_NAME]
+  );
+  return result.insertId;
+}
+
+async function ensureAdminUser(connection, regionalCenterId) {
+  const [existing] = await connection.execute('SELECT id FROM users WHERE email = ?', [ADMIN_EMAIL]);
+  if (existing.length > 0) {
+    return;
+  }
+
+  const encryptedPassword = bcrypt.hashSync(ADMIN_PASSWORD, BCRYPT_COST);
+
+  await connection.execute(
+    `INSERT INTO users (
+       email, encrypted_password, zdp, first_name, last_name, address, zip, role,
+       city, hometown, birthday, phone, bank_iban, health_insurance,
+       regional_center_id, created_at, updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())`,
+    [
+      ADMIN_EMAIL,
+      encryptedPassword,
+      ADMIN_ZDP,
+      'Integration',
+      'Admin',
+      'Teststrasse 1',
+      8000,
+      1, // enum role: admin
+      'Testcity',
+      'Testhometown',
+      '2000-01-01',
+      '079 000 00 00',
+      'CH9300762011623852957',
+      'Testversicherung',
+      regionalCenterId,
+    ]
+  );
+}

--- a/integration-tests/jest.config.js
+++ b/integration-tests/jest.config.js
@@ -1,0 +1,8 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts'],
+  testTimeout: 30000,
+  globalSetup: '<rootDir>/globalSetup.js',
+};

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -1,0 +1,4317 @@
+{
+  "name": "izivi-integration-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "izivi-integration-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/bcryptjs": "^2.4.6",
+        "@types/jest": "^29.5.12",
+        "@types/node": "^20.14.9",
+        "axios": "^1.7.2",
+        "bcryptjs": "^3.0.3",
+        "jest": "^29.7.0",
+        "mysql2": "^3.22.5",
+        "ts-jest": "^29.1.5",
+        "typescript": "^5.5.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.42",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.387",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
+      "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mysql2": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.5.tgz",
+      "integrity": "sha512-95uZ2TrPWAZdwpB3vvvDbmEMcNG8yIeNCyu6GUcr/QnWEE/wXm7+mhOCsdQfWQDTV7qYT/PDUZ4U4UPP4AsXqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.2",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.2",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.3.3"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/sql-escaper": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.3.tgz",
+      "integrity": "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.8.0",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "izivi-integration-tests",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Black-box HTTP integration tests for the Better-iZivi Rails API. Written in TypeScript so the suite is unaffected by the Ruby/Rails upgrade it guards.",
+  "scripts": {
+    "test": "jest --runInBand"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.14.9",
+    "axios": "^1.7.2",
+    "bcryptjs": "^3.0.3",
+    "jest": "^29.7.0",
+    "mysql2": "^3.22.5",
+    "ts-jest": "^29.1.5",
+    "typescript": "^5.5.3"
+  }
+}

--- a/integration-tests/src/auth.ts
+++ b/integration-tests/src/auth.ts
@@ -1,0 +1,43 @@
+import { client } from './client';
+
+export interface Credentials {
+  email: string;
+  password: string;
+}
+
+// Must match the ADMIN_EMAIL/ADMIN_PASSWORD constants in globalSetup.js,
+// which inserts this user directly via SQL before the suite runs (see that
+// file for why: it deliberately does not go through `rails db:seed`).
+export const ADMIN_CREDENTIALS: Credentials = {
+  email: 'integration-test-admin@example.com',
+  password: 'password123',
+};
+
+export interface Session {
+  token: string;
+  userId: number;
+}
+
+export async function signIn(credentials: Credentials): Promise<Session> {
+  const response = await client.post('/v1/users/sign_in', { user: credentials });
+
+  if (response.status !== 200) {
+    throw new Error(
+      `Sign in failed for ${credentials.email}: ${response.status} ${JSON.stringify(response.data)}`
+    );
+  }
+
+  const authHeader = response.headers['authorization'] as string | undefined;
+  if (!authHeader) {
+    throw new Error('Sign in response did not include an Authorization header');
+  }
+
+  return {
+    token: authHeader.replace(/^Bearer /, ''),
+    userId: response.data.id,
+  };
+}
+
+export function signInAsAdmin(): Promise<Session> {
+  return signIn(ADMIN_CREDENTIALS);
+}

--- a/integration-tests/src/client.ts
+++ b/integration-tests/src/client.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+import http from 'http';
+
+export const API_BASE_URL = process.env.API_BASE_URL ?? 'http://localhost:28000';
+
+// Every test asserts on `response.status` itself, so let axios resolve
+// (rather than throw) for 4xx/5xx responses too.
+export const client = axios.create({
+  baseURL: API_BASE_URL,
+  validateStatus: () => true,
+  // Avoid reusing a single keep-alive socket across this suite's ~70+
+  // sequential requests — Node accumulates an error listener on it per
+  // request and eventually warns (MaxListenersExceededWarning).
+  httpAgent: new http.Agent({ keepAlive: false }),
+});
+
+export function authHeaders(token: string): { Authorization: string } {
+  return { Authorization: `Bearer ${token}` };
+}

--- a/integration-tests/src/dates.ts
+++ b/integration-tests/src/dates.ts
@@ -1,5 +1,8 @@
 function toISODate(date: Date): string {
-  return date.toISOString().slice(0, 10);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 /**

--- a/integration-tests/src/dates.ts
+++ b/integration-tests/src/dates.ts
@@ -1,0 +1,24 @@
+function toISODate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * A valid "normal" service date range: begins on a Monday, ends 25 days
+ * later on a Friday (the minimum length Service#length_is_valid allows).
+ * `weeksFromNow` shifts the whole range into a dedicated slice of the
+ * calendar so unrelated tests never collide on the same user's services.
+ */
+export function normalServiceRange(weeksFromNow: number): { beginning: string; ending: string } {
+  const now = new Date();
+  const daysUntilNextMonday = ((1 - now.getDay() + 7) % 7) || 7;
+
+  const beginning = new Date(now);
+  beginning.setDate(now.getDate() + daysUntilNextMonday + weeksFromNow * 7);
+
+  const ending = new Date(beginning);
+  ending.setDate(beginning.getDate() + 25);
+
+  return { beginning: toISODate(beginning), ending: toISODate(ending) };
+}
+
+export { toISODate };

--- a/integration-tests/src/dimeMock.ts
+++ b/integration-tests/src/dimeMock.ts
@@ -57,8 +57,8 @@ function generateSelfSignedCert(): { certPem: string; keyPem: string } {
   return { certPem, keyPem };
 }
 
-const MOCK_DIME_TOKEN = 'mock-dime-token';
-const MOCK_DIME_EMPLOYEE_ID = 4242;
+export const MOCK_DIME_TOKEN = 'mock-dime-token';
+export const MOCK_DIME_EMPLOYEE_ID = 4242;
 
 export async function startDimeMock(): Promise<DimeMock> {
   const { certPem, keyPem } = generateSelfSignedCert();

--- a/integration-tests/src/dimeMock.ts
+++ b/integration-tests/src/dimeMock.ts
@@ -10,7 +10,6 @@ import path from 'path';
 // at this mock (see dockerDime.ts) — so the mock has to actually terminate
 // TLS with a certificate the container is willing to trust, not just listen
 // on plain HTTP.
-export const MOCK_HOST_IP = '172.20.0.1'; // the docker-compose bridge network's gateway, reachable from the api container as "the host"
 
 export interface RecordedRequest {
   method: string;
@@ -27,7 +26,7 @@ export interface DimeMock {
   stop: () => Promise<void>;
 }
 
-function generateSelfSignedCert(): { certPem: string; keyPem: string } {
+function generateSelfSignedCert(hostIp: string): { certPem: string; keyPem: string } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dime-mock-cert-'));
   const keyPath = path.join(dir, 'key.pem');
   const certPath = path.join(dir, 'cert.pem');
@@ -47,7 +46,7 @@ function generateSelfSignedCert(): { certPem: string; keyPem: string } {
     '-subj',
     '/CN=dime-mock',
     '-addext',
-    `subjectAltName=IP:${MOCK_HOST_IP}`,
+    `subjectAltName=IP:${hostIp}`,
   ]);
 
   const certPem = fs.readFileSync(certPath, 'utf8');
@@ -60,8 +59,8 @@ function generateSelfSignedCert(): { certPem: string; keyPem: string } {
 export const MOCK_DIME_TOKEN = 'mock-dime-token';
 export const MOCK_DIME_EMPLOYEE_ID = 4242;
 
-export async function startDimeMock(): Promise<DimeMock> {
-  const { certPem, keyPem } = generateSelfSignedCert();
+export async function startDimeMock(hostIp: string): Promise<DimeMock> {
+  const { certPem, keyPem } = generateSelfSignedCert(hostIp);
   const requests: RecordedRequest[] = [];
   let projectEffortsCount = 1;
   let employeeFound = true;
@@ -69,7 +68,7 @@ export async function startDimeMock(): Promise<DimeMock> {
   const server = https.createServer({ cert: certPem, key: keyPem }, (req, res) => {
     requests.push({ method: req.method ?? '', url: req.url ?? '', headers: req.headers });
 
-    const url = new URL(req.url ?? '', `https://${MOCK_HOST_IP}`);
+    const url = new URL(req.url ?? '', `https://${hostIp}`);
 
     if (req.method === 'POST' && url.pathname === '/v2/employees/sign_in') {
       res.writeHead(200, { Authorization: MOCK_DIME_TOKEN, 'Content-Type': 'application/json' });

--- a/integration-tests/src/dimeMock.ts
+++ b/integration-tests/src/dimeMock.ts
@@ -1,0 +1,120 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import https from 'https';
+import os from 'os';
+import path from 'path';
+
+// AuthenticateInDime (api/app/services/authenticate_in_dime.rb) hardcodes
+// `use_ssl = true` and `verify_mode = OpenSSL::SSL::VERIFY_PEER`, and always
+// connects to whatever host ends up in API_URI_DIME by IP once we point it
+// at this mock (see dockerDime.ts) — so the mock has to actually terminate
+// TLS with a certificate the container is willing to trust, not just listen
+// on plain HTTP.
+export const MOCK_HOST_IP = '172.20.0.1'; // the docker-compose bridge network's gateway, reachable from the api container as "the host"
+
+export interface RecordedRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string | string[] | undefined>;
+}
+
+export interface DimeMock {
+  port: number;
+  certPem: string;
+  requests: () => RecordedRequest[];
+  setProjectEffortsCount: (count: number) => void;
+  setEmployeeFound: (found: boolean) => void;
+  stop: () => Promise<void>;
+}
+
+function generateSelfSignedCert(): { certPem: string; keyPem: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dime-mock-cert-'));
+  const keyPath = path.join(dir, 'key.pem');
+  const certPath = path.join(dir, 'cert.pem');
+
+  execFileSync('openssl', [
+    'req',
+    '-x509',
+    '-newkey',
+    'rsa:2048',
+    '-nodes',
+    '-keyout',
+    keyPath,
+    '-out',
+    certPath,
+    '-days',
+    '1',
+    '-subj',
+    '/CN=dime-mock',
+    '-addext',
+    `subjectAltName=IP:${MOCK_HOST_IP}`,
+  ]);
+
+  const certPem = fs.readFileSync(certPath, 'utf8');
+  const keyPem = fs.readFileSync(keyPath, 'utf8');
+  fs.rmSync(dir, { recursive: true, force: true });
+
+  return { certPem, keyPem };
+}
+
+const MOCK_DIME_TOKEN = 'mock-dime-token';
+const MOCK_DIME_EMPLOYEE_ID = 4242;
+
+export async function startDimeMock(): Promise<DimeMock> {
+  const { certPem, keyPem } = generateSelfSignedCert();
+  const requests: RecordedRequest[] = [];
+  let projectEffortsCount = 1;
+  let employeeFound = true;
+
+  const server = https.createServer({ cert: certPem, key: keyPem }, (req, res) => {
+    requests.push({ method: req.method ?? '', url: req.url ?? '', headers: req.headers });
+
+    const url = new URL(req.url ?? '', `https://${MOCK_HOST_IP}`);
+
+    if (req.method === 'POST' && url.pathname === '/v2/employees/sign_in') {
+      res.writeHead(200, { Authorization: MOCK_DIME_TOKEN, 'Content-Type': 'application/json' });
+      res.end('{}');
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/v2/employees') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ data: employeeFound ? [{ id: MOCK_DIME_EMPLOYEE_ID }] : [] }));
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/v2/project_efforts') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(Array.from({ length: projectEffortsCount }, (_, i) => ({ id: i }))));
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: `mock DIME server has no handler for ${req.method} ${url.pathname}` }));
+  });
+
+  const port = await new Promise<number>((resolve, reject) => {
+    server.on('error', reject);
+    server.listen(0, '0.0.0.0', () => {
+      const address = server.address();
+      if (address === null || typeof address === 'string') {
+        reject(new Error('Expected the mock DIME server to bind to a TCP port'));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+
+  return {
+    port,
+    certPem,
+    requests: () => requests,
+    setProjectEffortsCount: (count: number) => {
+      projectEffortsCount = count;
+    },
+    setEmployeeFound: (found: boolean) => {
+      employeeFound = found;
+    },
+    stop: () => new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+  };
+}

--- a/integration-tests/src/dockerDime.ts
+++ b/integration-tests/src/dockerDime.ts
@@ -13,6 +13,30 @@ function dockerCompose(args: string[], env: NodeJS.ProcessEnv = process.env): vo
 }
 
 /**
+ * The docker-compose bridge network's gateway IP, reachable from inside the
+ * `api` container as "the host". docker-compose.yml doesn't pin a subnet, so
+ * Docker picks one (and therefore this gateway) dynamically — reading it off
+ * the running container instead of hardcoding it keeps this working
+ * regardless of what Docker assigns.
+ */
+export function getApiContainerGatewayIp(): string {
+  const gateway = execFileSync('docker', [
+    'inspect',
+    API_CONTAINER,
+    '--format',
+    '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}',
+  ])
+    .toString()
+    .trim();
+
+  if (!gateway) {
+    throw new Error(`Could not determine the docker bridge gateway IP for container ${API_CONTAINER}`);
+  }
+
+  return gateway;
+}
+
+/**
  * Recreates the `api` container from docker-compose.yml with API_URI_DIME
  * pointed at our mock (or, called with no argument, back at whatever
  * docker-compose.yml defaults it to). This is the only way to change it:

--- a/integration-tests/src/dockerDime.ts
+++ b/integration-tests/src/dockerDime.ts
@@ -1,0 +1,81 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { client } from './client';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const API_CONTAINER = 'better_izivi_api';
+const API_SERVICE = 'api';
+
+function dockerCompose(args: string[], env: NodeJS.ProcessEnv = process.env): void {
+  execFileSync('docker', ['compose', ...args], { cwd: REPO_ROOT, env, stdio: 'pipe' });
+}
+
+/**
+ * Recreates the `api` container from docker-compose.yml with API_URI_DIME
+ * pointed at our mock (or, called with no argument, back at whatever
+ * docker-compose.yml defaults it to). This is the only way to change it:
+ * AuthenticateInDime reads `ENV.fetch('API_URI_DIME')` fresh on every call,
+ * but that env var is only ever set once, at process boot — `docker exec`
+ * into the running container wouldn't reach the already-running Puma
+ * process's environment.
+ */
+export function recreateApiContainer(apiUriDime?: string): void {
+  const env = { ...process.env };
+  if (apiUriDime) {
+    env.API_URI_DIME = apiUriDime;
+  } else {
+    delete env.API_URI_DIME;
+  }
+
+  dockerCompose(['up', '-d', '--force-recreate', API_SERVICE], env);
+}
+
+/**
+ * Installs `certPem` as a trusted CA inside the (freshly recreated) api
+ * container. AuthenticateInDime hardcodes `verify_mode = VERIFY_PEER`, so
+ * without this the container's Ruby process will refuse to complete the
+ * TLS handshake with our self-signed mock.
+ */
+export function installCaCertInApiContainer(certPem: string): void {
+  const tmpFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'dime-mock-ca-')), 'dime-mock.crt');
+  fs.writeFileSync(tmpFile, certPem);
+
+  try {
+    execFileSync('docker', ['cp', tmpFile, `${API_CONTAINER}:/tmp/dime-mock.crt`], { stdio: 'pipe' });
+    execFileSync(
+      'docker',
+      [
+        'exec',
+        '-u',
+        'root',
+        API_CONTAINER,
+        'sh',
+        '-c',
+        'cp /tmp/dime-mock.crt /usr/local/share/ca-certificates/dime-mock.crt && update-ca-certificates',
+      ],
+      { stdio: 'pipe' }
+    );
+  } finally {
+    fs.rmSync(path.dirname(tmpFile), { recursive: true, force: true });
+  }
+}
+
+export async function waitForApiReady(timeoutMs = 60000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await client.get('/v1/regional_centers', { timeout: 2000 });
+      if (response.status === 200) {
+        return;
+      }
+    } catch {
+      // still booting — fall through and retry
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error(`api container did not become ready within ${timeoutMs}ms`);
+}

--- a/integration-tests/src/fixtures.ts
+++ b/integration-tests/src/fixtures.ts
@@ -71,7 +71,7 @@ export async function registerCivilServant(
       zip: '8000',
       hometown: 'Testhometown',
       phone: '079 000 00 00',
-      zdp: 100_000 + (Date.now() % 800_000),
+      zdp: 100_000 + (Math.floor(Date.now() + Math.random() * 1_000_000) % 800_000),
       regional_center_id: regionalCenterId,
       ...overrides,
     },
@@ -158,6 +158,12 @@ export async function createService(
     params: { beginning, ending },
     headers: authHeaders(adminToken),
   });
+
+  if (calculated.status !== 200 || typeof calculated.data?.result !== 'number') {
+    throw new Error(
+      `Failed to calculate service days: ${calculated.status} ${JSON.stringify(calculated.data)}`
+    );
+  }
 
   const response = await client.post(
     '/v1/services',

--- a/integration-tests/src/fixtures.ts
+++ b/integration-tests/src/fixtures.ts
@@ -1,0 +1,197 @@
+import { client, authHeaders } from './client';
+import { Session, signIn } from './auth';
+import { normalServiceRange } from './dates';
+
+// Must match REGIONAL_CENTER_SHORT_NAME in globalSetup.js.
+export const BOOTSTRAP_REGIONAL_CENTER_SHORT_NAME = 'IT-Bootstrap';
+
+let cachedRegionalCenterId: number | undefined;
+
+/**
+ * Returns the id of the regional center globalSetup.js inserted via SQL.
+ * Falls back to whatever the index returns first if it's somehow missing,
+ * so this still works if the suite is ever pointed at a database that also
+ * has `rails db:seed`'s regional centers loaded.
+ */
+export async function firstRegionalCenterId(): Promise<number> {
+  if (cachedRegionalCenterId !== undefined) {
+    return cachedRegionalCenterId;
+  }
+
+  const response = await client.get('/v1/regional_centers');
+  if (response.status !== 200 || !Array.isArray(response.data) || response.data.length === 0) {
+    throw new Error(
+      `Expected at least one regional center (globalSetup.js should have created one), got ${response.status} ${JSON.stringify(response.data)}`
+    );
+  }
+
+  const bootstrapped = response.data.find(
+    (center: { short_name: string }) => center.short_name === BOOTSTRAP_REGIONAL_CENTER_SHORT_NAME
+  );
+  cachedRegionalCenterId = (bootstrapped ?? response.data[0]).id;
+  return cachedRegionalCenterId as number;
+}
+
+export interface RegisteredUser {
+  email: string;
+  password: string;
+  id: number;
+}
+
+function uniqueSuffix(): string {
+  return `${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
+}
+
+/**
+ * Registers a brand new civil servant through the public self-registration
+ * endpoint, so tests that mutate a user's services/expense sheets don't
+ * disturb the shared seeded fixtures other tests rely on.
+ */
+export async function registerCivilServant(
+  overrides: Record<string, unknown> = {}
+): Promise<RegisteredUser> {
+  const suffix = uniqueSuffix();
+  const email = `integration-test-${suffix}@example.com`;
+  const password = 'password123';
+  const regionalCenterId = await firstRegionalCenterId();
+
+  const response = await client.post('/v1/users', {
+    user: {
+      email,
+      password,
+      password_confirmation: password,
+      community_password: process.env.COMMUNITY_PASSWORD ?? '123456',
+      first_name: 'Integration',
+      last_name: 'Test',
+      address: 'Teststrasse 1',
+      bank_iban: 'CH9300762011623852957',
+      birthday: '2005-01-01',
+      city: 'Testcity',
+      health_insurance: 'Testversicherung',
+      zip: '8000',
+      hometown: 'Testhometown',
+      phone: '079 000 00 00',
+      zdp: 100_000 + (Date.now() % 800_000),
+      regional_center_id: regionalCenterId,
+      ...overrides,
+    },
+  });
+
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(
+      `Failed to register test user: ${response.status} ${JSON.stringify(response.data)}`
+    );
+  }
+
+  return { email, password, id: response.data.id };
+}
+
+/** Registers a fresh civil servant and signs them in, in one call. */
+export async function registerAndSignInCivilServant(
+  overrides: Record<string, unknown> = {}
+): Promise<Session> {
+  const user = await registerCivilServant(overrides);
+  return signIn({ email: user.email, password: user.password });
+}
+
+const dayExpenses = { breakfast: 0, lunch: 0, dinner: 0 };
+
+/**
+ * Creates a fresh ServiceSpecification via the admin API. Tests that need a
+ * service_specification_id to create a Service should call this rather than
+ * assuming a seeded id (e.g. `1`) exists.
+ */
+export async function createServiceSpecification(adminToken: string): Promise<number> {
+  const suffix = uniqueSuffix();
+
+  const response = await client.post(
+    '/v1/service_specifications',
+    {
+      service_specification: {
+        name: `Integration Test Spec ${suffix}`,
+        short_name: 'IT',
+        identification_number: suffix.replace('-', '').slice(-6),
+        // NB: keep this non-zero — ExpenseSheetCalculators::SuggestionsCalculator
+        // divides by it unconditionally in #calculate_to_pay_days and 500s on 0.
+        work_clothing_expenses: 230,
+        accommodation_expenses: 0,
+        location: 'zurich',
+        active: true,
+        work_days_expenses: dayExpenses,
+        paid_vacation_expenses: dayExpenses,
+        first_day_expenses: dayExpenses,
+        last_day_expenses: dayExpenses,
+      },
+    },
+    { headers: authHeaders(adminToken) }
+  );
+
+  if (response.status !== 201) {
+    throw new Error(
+      `Failed to create test service specification: ${response.status} ${JSON.stringify(response.data)}`
+    );
+  }
+
+  return response.data.id;
+}
+
+export interface CreatedService {
+  id: number;
+  beginning: string;
+  ending: string;
+}
+
+/**
+ * Creates (as admin) a valid "normal" service for `userId`, computing
+ * service_days the same way the frontend does: call calculate_service_days
+ * first, then pass the result into the create call.
+ */
+export async function createService(
+  adminToken: string,
+  userId: number,
+  serviceSpecificationId: number,
+  weeksFromNow: number
+): Promise<CreatedService> {
+  const { beginning, ending } = normalServiceRange(weeksFromNow);
+
+  const calculated = await client.get('/v1/services/calculate_service_days', {
+    params: { beginning, ending },
+    headers: authHeaders(adminToken),
+  });
+
+  const response = await client.post(
+    '/v1/services',
+    {
+      service: {
+        user_id: userId,
+        service_specification_id: serviceSpecificationId,
+        beginning,
+        ending,
+        service_type: 'normal',
+        service_days: calculated.data.result,
+        first_swo_service: true,
+        long_service: false,
+        probation_service: false,
+      },
+    },
+    { headers: authHeaders(adminToken) }
+  );
+
+  if (response.status !== 201) {
+    throw new Error(`Failed to create test service: ${response.status} ${JSON.stringify(response.data)}`);
+  }
+
+  return response.data;
+}
+
+/** Creates a service via createService() and immediately confirms it (generating expense sheets). */
+export async function createConfirmedService(
+  adminToken: string,
+  userId: number,
+  serviceSpecificationId: number,
+  weeksFromNow: number
+): Promise<CreatedService> {
+  const service = await createService(adminToken, userId, serviceSpecificationId, weeksFromNow);
+  await client.put(`/v1/services/${service.id}/confirm`, {}, { headers: authHeaders(adminToken) });
+  return service;
+}

--- a/integration-tests/src/mail.ts
+++ b/integration-tests/src/mail.ts
@@ -1,0 +1,59 @@
+import fs from 'fs';
+import path from 'path';
+
+// The dev API's ActionMailer delivery_method is `letter_opener` (see
+// config/environments/development.rb), which writes each outgoing email as
+// an HTML file under api/tmp/letter_opener/<id>/rich.html instead of
+// actually sending it. docker-compose bind-mounts ./api into the container,
+// so this directory is readable from the host too.
+const LETTER_OPENER_DIR =
+  process.env.LETTER_OPENER_DIR ?? path.resolve(__dirname, '..', '..', 'api', 'tmp', 'letter_opener');
+
+/**
+ * Polls for a password-reset email delivered after `since` and returns the
+ * raw reset token embedded in its body. Devise only ever stores a digest of
+ * this token (`users.reset_password_token` in the DB is not the token
+ * itself), so the delivered email is the only place the raw value appears.
+ */
+export async function waitForPasswordResetToken(since: Date, timeoutMs = 5000): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const token = findPasswordResetToken(since);
+    if (token) {
+      return token;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  throw new Error(`No password reset email appeared in ${LETTER_OPENER_DIR} after ${since.toISOString()}`);
+}
+
+function findPasswordResetToken(since: Date): string | undefined {
+  if (!fs.existsSync(LETTER_OPENER_DIR)) {
+    return undefined;
+  }
+
+  const candidates = fs
+    .readdirSync(LETTER_OPENER_DIR)
+    .map((name) => {
+      const dir = path.join(LETTER_OPENER_DIR, name);
+      return { dir, mtimeMs: fs.statSync(dir).mtimeMs };
+    })
+    .filter((entry) => entry.mtimeMs >= since.getTime())
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  for (const { dir } of candidates) {
+    const filePath = path.join(dir, 'rich.html');
+    if (!fs.existsSync(filePath)) {
+      continue;
+    }
+
+    const match = fs.readFileSync(filePath, 'utf8').match(/passwords\/edit\/([A-Za-z0-9_-]+)/);
+    if (match) {
+      return match[1];
+    }
+  }
+
+  return undefined;
+}

--- a/integration-tests/tests/auth.test.ts
+++ b/integration-tests/tests/auth.test.ts
@@ -1,0 +1,102 @@
+import { client, authHeaders } from '../src/client';
+import { signIn, signInAsAdmin } from '../src/auth';
+import { registerCivilServant } from '../src/fixtures';
+
+describe('POST /v1/users/sign_in', () => {
+  it('signs in a freshly registered civil servant and returns a bearer token', async () => {
+    const user = await registerCivilServant();
+    const session = await signIn(user);
+
+    expect(session.token).toEqual(expect.any(String));
+    expect(session.token.length).toBeGreaterThan(10);
+  });
+
+  it('signs in the bootstrap admin', async () => {
+    const session = await signInAsAdmin();
+
+    expect(session.userId).toEqual(expect.any(Number));
+  });
+
+  it('rejects an incorrect password', async () => {
+    const user = await registerCivilServant();
+    const response = await client.post('/v1/users/sign_in', {
+      user: { email: user.email, password: 'wrong-password' },
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers['authorization']).toBeUndefined();
+  });
+
+  it('rejects an unknown email', async () => {
+    const response = await client.post('/v1/users/sign_in', {
+      user: { email: 'nobody@example.com', password: 'whatever' },
+    });
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe('POST /v1/users/validate', () => {
+  it('accepts valid, not-yet-taken registration fields', async () => {
+    const response = await client.post('/v1/users/validate', {
+      user: { email: `validate-${Date.now()}@example.com`, zdp: 222333, community_password: '123456' },
+    });
+
+    expect(response.status).toBe(204);
+  });
+
+  it('rejects a duplicate email with a structured error', async () => {
+    const user = await registerCivilServant();
+
+    const response = await client.post('/v1/users/validate', {
+      user: { email: user.email, zdp: 222334, community_password: '123456' },
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.data).toEqual(
+      expect.objectContaining({ errors: expect.any(Object), human_readable_descriptions: expect.any(Array) })
+    );
+  });
+
+  it('rejects an incorrect community password', async () => {
+    const response = await client.post('/v1/users/validate', {
+      user: { email: `validate-${Date.now()}@example.com`, zdp: 222335, community_password: 'wrong' },
+    });
+
+    expect(response.status).toBe(400);
+  });
+});
+
+describe('DELETE /v1/users/sign_out', () => {
+  it('revokes the token via the JWT allowlist so it can no longer be used', async () => {
+    const user = await registerCivilServant();
+    const session = await signIn(user);
+
+    const signOutResponse = await client.delete('/v1/users/sign_out', {
+      headers: authHeaders(session.token),
+    });
+    expect(signOutResponse.status).toBe(204);
+
+    const reuseResponse = await client.get(`/v1/users/${session.userId}`, {
+      headers: authHeaders(session.token),
+    });
+    expect(reuseResponse.status).toBe(401);
+  });
+});
+
+describe('authentication requirement', () => {
+  it('rejects unauthenticated access to a protected resource', async () => {
+    const response = await client.get('/v1/users/1');
+
+    expect(response.status).toBe(401);
+    expect(response.data).toHaveProperty('error');
+  });
+
+  it('rejects requests with a garbage bearer token', async () => {
+    const response = await client.get('/v1/users/1', {
+      headers: authHeaders('not-a-real-token'),
+    });
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/integration-tests/tests/auth.test.ts
+++ b/integration-tests/tests/auth.test.ts
@@ -39,7 +39,11 @@ describe('POST /v1/users/sign_in', () => {
 describe('POST /v1/users/validate', () => {
   it('accepts valid, not-yet-taken registration fields', async () => {
     const response = await client.post('/v1/users/validate', {
-      user: { email: `validate-${Date.now()}@example.com`, zdp: 222333, community_password: '123456' },
+      user: {
+        email: `validate-${Date.now()}@example.com`,
+        zdp: 222333,
+        community_password: process.env.COMMUNITY_PASSWORD ?? '123456',
+      },
     });
 
     expect(response.status).toBe(204);
@@ -49,7 +53,7 @@ describe('POST /v1/users/validate', () => {
     const user = await registerCivilServant();
 
     const response = await client.post('/v1/users/validate', {
-      user: { email: user.email, zdp: 222334, community_password: '123456' },
+      user: { email: user.email, zdp: 222334, community_password: process.env.COMMUNITY_PASSWORD ?? '123456' },
     });
 
     expect(response.status).toBe(400);

--- a/integration-tests/tests/deviseSelfService.test.ts
+++ b/integration-tests/tests/deviseSelfService.test.ts
@@ -1,0 +1,47 @@
+import { client, authHeaders } from '../src/client';
+import { signIn } from '../src/auth';
+import { registerCivilServant } from '../src/fixtures';
+
+// These hit devise's own registrations#update / #destroy (PATCH/PUT and
+// DELETE on the bare /v1/users collection route) — a separate code path
+// from V1::UsersController's admin-facing /v1/users/:id, which is covered
+// in users.test.ts.
+describe('Devise self-service profile (PATCH/DELETE /v1/users)', () => {
+  it('requires current_password to change your own profile', async () => {
+    const user = await registerCivilServant();
+    const session = await signIn(user);
+
+    const withoutPassword = await client.put(
+      '/v1/users',
+      { user: { first_name: 'Changed' } },
+      { headers: authHeaders(session.token) }
+    );
+    // NB: this is devise's own registrations#update, not our ValidationError
+    // pipeline (which uses 400) — devise renders its own errors as 422.
+    expect(withoutPassword.status).toBe(422);
+
+    const withPassword = await client.put(
+      '/v1/users',
+      { user: { first_name: 'Changed', current_password: user.password } },
+      { headers: authHeaders(session.token) }
+    );
+    expect(withPassword.status).toBe(204);
+  });
+
+  it('rejects an unauthenticated profile update', async () => {
+    const response = await client.put('/v1/users', { user: { first_name: 'Nope' } });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('lets a user delete their own account (with no services)', async () => {
+    const user = await registerCivilServant();
+    const session = await signIn(user);
+
+    const response = await client.delete('/v1/users', { headers: authHeaders(session.token) });
+    expect(response.status).toBe(204);
+
+    const loginAfterDelete = await client.post('/v1/users/sign_in', { user });
+    expect(loginAfterDelete.status).toBe(401);
+  });
+});

--- a/integration-tests/tests/dimeSickDays.test.ts
+++ b/integration-tests/tests/dimeSickDays.test.ts
@@ -1,0 +1,108 @@
+import { client, authHeaders } from '../src/client';
+import { signInAsAdmin, Session } from '../src/auth';
+import { createConfirmedService, createServiceSpecification, registerCivilServant } from '../src/fixtures';
+import { DimeMock, MOCK_HOST_IP, startDimeMock } from '../src/dimeMock';
+import { installCaCertInApiContainer, recreateApiContainer, waitForApiReady } from '../src/dockerDime';
+
+// GET /v1/expenses_sheet_sick_days_dime calls out to an external DIME
+// service (AuthenticateInDime), unconditionally — CONNECT_TO_DIME only
+// gates the *other* DIME integration point (registration). To test this
+// for real (not just assert it 500s against the real, unreachable-from-here
+// DIME staging host) this spins up a local HTTPS mock standing in for DIME,
+// and recreates the `api` container pointed at it via API_URI_DIME. That
+// container is shared with every other test file in this suite, so setup
+// and teardown here are deliberately conservative: recreate, verify ready,
+// and always restore afterwards, even on failure.
+describe('GET /v1/expenses_sheet_sick_days_dime (against a mocked DIME backend)', () => {
+  let mock: DimeMock;
+  let admin: Session;
+  let serviceSpecificationId: number;
+
+  beforeAll(async () => {
+    mock = await startDimeMock();
+    recreateApiContainer(`https://${MOCK_HOST_IP}:${mock.port}`);
+    await waitForApiReady();
+    installCaCertInApiContainer(mock.certPem);
+
+    admin = await signInAsAdmin();
+    serviceSpecificationId = await createServiceSpecification(admin.token);
+  }, 120000);
+
+  afterAll(async () => {
+    try {
+      await mock.stop();
+    } finally {
+      recreateApiContainer();
+      await waitForApiReady();
+    }
+  }, 120000);
+
+  it("forwards the expense sheet's user and date range to DIME, and returns the sick day count DIME reports", async () => {
+    mock.setProjectEffortsCount(3);
+
+    const user = await registerCivilServant();
+    await createConfirmedService(admin.token, user.id, serviceSpecificationId, 900);
+    const userResponse = await client.get(`/v1/users/${user.id}`, { headers: authHeaders(admin.token) });
+    const expenseSheet = userResponse.data.expense_sheets[0];
+
+    const response = await client.get('/v1/expenses_sheet_sick_days_dime', {
+      params: { id: expenseSheet.id },
+      headers: authHeaders(admin.token),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.data).toEqual({ sick_days: 3 });
+
+    const requests = mock.requests();
+    expect(requests).toEqual(
+      expect.arrayContaining([expect.objectContaining({ method: 'POST', url: '/v2/employees/sign_in' })])
+    );
+
+    const searchRequest = requests.find((r) => r.method === 'GET' && r.url.startsWith('/v2/employees?'));
+    expect(searchRequest).toBeDefined();
+    expect(decodeURIComponent(searchRequest!.url)).toContain(`filterSearch=${user.email}`);
+    expect(searchRequest!.headers.authorization).toBe('mock-dime-token');
+
+    const effortsRequest = requests.find((r) => r.method === 'GET' && r.url.startsWith('/v2/project_efforts?'));
+    expect(effortsRequest).toBeDefined();
+    expect(effortsRequest!.url).toContain(`start=${expenseSheet.beginning}`);
+    expect(effortsRequest!.url).toContain(`end=${expenseSheet.ending}`);
+    expect(effortsRequest!.url).toContain('employee_ids=4242');
+  });
+
+  it('returns -1 when DIME has no matching employee', async () => {
+    mock.setEmployeeFound(false);
+
+    const user = await registerCivilServant();
+    await createConfirmedService(admin.token, user.id, serviceSpecificationId, 903);
+    const userResponse = await client.get(`/v1/users/${user.id}`, { headers: authHeaders(admin.token) });
+    const expenseSheet = userResponse.data.expense_sheets[0];
+
+    const response = await client.get('/v1/expenses_sheet_sick_days_dime', {
+      params: { id: expenseSheet.id },
+      headers: authHeaders(admin.token),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.data).toEqual({ sick_days: -1 });
+
+    mock.setEmployeeFound(true);
+  });
+
+  it('reflects a different DIME sick-day count for a different expense sheet', async () => {
+    mock.setProjectEffortsCount(0);
+
+    const user = await registerCivilServant();
+    await createConfirmedService(admin.token, user.id, serviceSpecificationId, 905);
+    const userResponse = await client.get(`/v1/users/${user.id}`, { headers: authHeaders(admin.token) });
+    const expenseSheet = userResponse.data.expense_sheets[0];
+
+    const response = await client.get('/v1/expenses_sheet_sick_days_dime', {
+      params: { id: expenseSheet.id },
+      headers: authHeaders(admin.token),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.data).toEqual({ sick_days: 0 });
+  });
+});

--- a/integration-tests/tests/dimeSickDays.test.ts
+++ b/integration-tests/tests/dimeSickDays.test.ts
@@ -1,8 +1,13 @@
 import { client, authHeaders } from '../src/client';
 import { signInAsAdmin, Session } from '../src/auth';
 import { createConfirmedService, createServiceSpecification, registerCivilServant } from '../src/fixtures';
-import { DimeMock, MOCK_DIME_EMPLOYEE_ID, MOCK_DIME_TOKEN, MOCK_HOST_IP, startDimeMock } from '../src/dimeMock';
-import { installCaCertInApiContainer, recreateApiContainer, waitForApiReady } from '../src/dockerDime';
+import { DimeMock, MOCK_DIME_EMPLOYEE_ID, MOCK_DIME_TOKEN, startDimeMock } from '../src/dimeMock';
+import {
+  getApiContainerGatewayIp,
+  installCaCertInApiContainer,
+  recreateApiContainer,
+  waitForApiReady,
+} from '../src/dockerDime';
 
 // GET /v1/expenses_sheet_sick_days_dime calls out to an external DIME
 // service (AuthenticateInDime), unconditionally — CONNECT_TO_DIME only
@@ -19,8 +24,9 @@ describe('GET /v1/expenses_sheet_sick_days_dime (against a mocked DIME backend)'
   let serviceSpecificationId: number;
 
   beforeAll(async () => {
-    mock = await startDimeMock();
-    recreateApiContainer(`https://${MOCK_HOST_IP}:${mock.port}`);
+    const hostIp = getApiContainerGatewayIp();
+    mock = await startDimeMock(hostIp);
+    recreateApiContainer(`https://${hostIp}:${mock.port}`);
     await waitForApiReady();
     installCaCertInApiContainer(mock.certPem);
 

--- a/integration-tests/tests/dimeSickDays.test.ts
+++ b/integration-tests/tests/dimeSickDays.test.ts
@@ -1,7 +1,7 @@
 import { client, authHeaders } from '../src/client';
 import { signInAsAdmin, Session } from '../src/auth';
 import { createConfirmedService, createServiceSpecification, registerCivilServant } from '../src/fixtures';
-import { DimeMock, MOCK_HOST_IP, startDimeMock } from '../src/dimeMock';
+import { DimeMock, MOCK_DIME_EMPLOYEE_ID, MOCK_DIME_TOKEN, MOCK_HOST_IP, startDimeMock } from '../src/dimeMock';
 import { installCaCertInApiContainer, recreateApiContainer, waitForApiReady } from '../src/dockerDime';
 
 // GET /v1/expenses_sheet_sick_days_dime calls out to an external DIME
@@ -61,13 +61,13 @@ describe('GET /v1/expenses_sheet_sick_days_dime (against a mocked DIME backend)'
     const searchRequest = requests.find((r) => r.method === 'GET' && r.url.startsWith('/v2/employees?'));
     expect(searchRequest).toBeDefined();
     expect(decodeURIComponent(searchRequest!.url)).toContain(`filterSearch=${user.email}`);
-    expect(searchRequest!.headers.authorization).toBe('mock-dime-token');
+    expect(searchRequest!.headers.authorization).toBe(MOCK_DIME_TOKEN);
 
     const effortsRequest = requests.find((r) => r.method === 'GET' && r.url.startsWith('/v2/project_efforts?'));
     expect(effortsRequest).toBeDefined();
     expect(effortsRequest!.url).toContain(`start=${expenseSheet.beginning}`);
     expect(effortsRequest!.url).toContain(`end=${expenseSheet.ending}`);
-    expect(effortsRequest!.url).toContain('employee_ids=4242');
+    expect(effortsRequest!.url).toContain(`employee_ids=${MOCK_DIME_EMPLOYEE_ID}`);
   });
 
   it('returns -1 when DIME has no matching employee', async () => {

--- a/integration-tests/tests/expenseSheets.test.ts
+++ b/integration-tests/tests/expenseSheets.test.ts
@@ -1,0 +1,143 @@
+import { client, authHeaders } from '../src/client';
+import { Session, signInAsAdmin } from '../src/auth';
+import {
+  createConfirmedService,
+  createServiceSpecification,
+  registerCivilServant,
+  registerAndSignInCivilServant,
+} from '../src/fixtures';
+
+describe('V1::ExpenseSheetsController', () => {
+  let admin: Session;
+  let civilServant: Session;
+  let serviceSpecificationId: number;
+  let weeksFromNow = 540;
+
+  async function freshExpenseSheets() {
+    const user = await registerCivilServant();
+    const service = await createConfirmedService(admin.token, user.id, serviceSpecificationId, weeksFromNow++);
+    const userResponse = await client.get(`/v1/users/${user.id}`, { headers: authHeaders(admin.token) });
+    return {
+      serviceId: service.id,
+      expenseSheets: userResponse.data.expense_sheets as { id: number }[],
+    };
+  }
+
+  beforeAll(async () => {
+    admin = await signInAsAdmin();
+    civilServant = await registerAndSignInCivilServant();
+    serviceSpecificationId = await createServiceSpecification(admin.token);
+  });
+
+  it('generates expense sheets when a service is confirmed, and exposes hints/update/pdf for them', async () => {
+    const { expenseSheets } = await freshExpenseSheets();
+    expect(expenseSheets.length).toBeGreaterThan(0);
+    const expenseSheetId = expenseSheets[0].id;
+
+    const hintsResponse = await client.get(`/v1/expense_sheets/${expenseSheetId}/hints`, {
+      headers: authHeaders(admin.token),
+    });
+    expect(hintsResponse.status).toBe(200);
+    expect(hintsResponse.data).toEqual(
+      expect.objectContaining({ suggestions: expect.any(Object), remaining_days: expect.any(Object) })
+    );
+
+    const updateResponse = await client.put(
+      `/v1/expense_sheets/${expenseSheetId}`,
+      { expense_sheet: { work_days: 1 } },
+      { headers: authHeaders(admin.token) }
+    );
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.data.work_days).toBe(1);
+
+    const pdfResponse = await client.get(`/v1/expense_sheets/${expenseSheetId}.pdf`, {
+      params: { token: admin.token },
+    });
+    expect(pdfResponse.status).toBe(200);
+    expect(pdfResponse.headers['content-type']).toContain('pdf');
+  });
+
+  it('rejects expense sheet update from a non-admin', async () => {
+    const { expenseSheets } = await freshExpenseSheets();
+
+    const response = await client.put(
+      `/v1/expense_sheets/${expenseSheets[0].id}`,
+      { expense_sheet: { work_days: 1 } },
+      { headers: authHeaders(civilServant.token) }
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects the pdf export without a valid token', async () => {
+    const { expenseSheets } = await freshExpenseSheets();
+
+    const response = await client.get(`/v1/expense_sheets/${expenseSheets[0].id}.pdf`, {
+      params: { token: 'not-a-real-token' },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('validates a not-yet-saved edit via live_hints', async () => {
+    const { expenseSheets } = await freshExpenseSheets();
+
+    const response = await client.post(
+      `/v1/expense_sheets/${expenseSheets[0].id}/live_hints`,
+      { expense_sheet: { work_days: 1 } },
+      { headers: authHeaders(admin.token) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.data).toEqual(
+      expect.objectContaining({ suggestions: expect.any(Object), remaining_days: expect.any(Object) })
+    );
+  });
+
+  it('lets an admin destroy an expense sheet', async () => {
+    const { expenseSheets } = await freshExpenseSheets();
+
+    const response = await client.delete(`/v1/expense_sheets/${expenseSheets[0].id}`, {
+      headers: authHeaders(admin.token),
+    });
+
+    expect(response.status).toBe(204);
+  });
+
+  it('shows a single expense sheet as json', async () => {
+    const { expenseSheets } = await freshExpenseSheets();
+
+    const response = await client.get(`/v1/expense_sheets/${expenseSheets[0].id}`, {
+      headers: authHeaders(admin.token),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.data.id).toBe(expenseSheets[0].id);
+  });
+
+  it('adds an additional expense sheet to a service', async () => {
+    const { serviceId } = await freshExpenseSheets();
+
+    const response = await client.post(
+      '/v1/expense_sheets',
+      {},
+      { params: { service_id: serviceId }, headers: authHeaders(admin.token) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.data.service_id).toBe(serviceId);
+  });
+
+  it('computes a total sum across expense sheets', async () => {
+    const response = await client.get('/v1/expenses_sheet_sum', { headers: authHeaders(admin.token) });
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.data)).toBe(true);
+  });
+
+  it('is admin-only for the index', async () => {
+    const response = await client.get('/v1/expense_sheets', { headers: authHeaders(civilServant.token) });
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/integration-tests/tests/exports.test.ts
+++ b/integration-tests/tests/exports.test.ts
@@ -1,0 +1,125 @@
+import { client, authHeaders } from '../src/client';
+import { Session, signInAsAdmin } from '../src/auth';
+import {
+  createServiceSpecification,
+  createService,
+  registerCivilServant,
+  registerAndSignInCivilServant,
+} from '../src/fixtures';
+
+describe('PDF export endpoints', () => {
+  let admin: Session;
+  let civilServant: Session;
+  let serviceId: number;
+
+  beforeAll(async () => {
+    admin = await signInAsAdmin();
+    civilServant = await registerAndSignInCivilServant();
+    const serviceSpecificationId = await createServiceSpecification(admin.token);
+    const user = await registerCivilServant();
+    const service = await createService(admin.token, user.id, serviceSpecificationId, 600);
+    serviceId = service.id;
+  });
+
+  describe('GET /v1/phone_list.pdf', () => {
+    it('is admin-only', async () => {
+      const response = await client.get('/v1/phone_list.pdf', {
+        params: { token: civilServant.token, phone_list: { beginning: '2030-01-01', ending: '2030-03-01' } },
+      });
+
+      expect(response.status).toBe(401);
+    });
+
+    it('renders a pdf for an admin token', async () => {
+      const response = await client.get('/v1/phone_list.pdf', {
+        params: { token: admin.token, phone_list: { beginning: '2030-01-01', ending: '2030-03-01' } },
+        responseType: 'arraybuffer',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toContain('pdf');
+    });
+
+    it('rejects a missing token', async () => {
+      const response = await client.get('/v1/phone_list.pdf', {
+        params: { phone_list: { beginning: '2030-01-01', ending: '2030-03-01' } },
+      });
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('GET /v1/payments_list.pdf', () => {
+    it('renders a pdf of pending payments for an admin token', async () => {
+      const response = await client.get('/v1/payments_list.pdf', {
+        params: { token: admin.token, payment: 'pending' },
+        responseType: 'arraybuffer',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toContain('pdf');
+    });
+
+    it('is admin-only', async () => {
+      const response = await client.get('/v1/payments_list.pdf', {
+        params: { token: civilServant.token, payment: 'pending' },
+      });
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('GET /v1/expenses_overview.pdf', () => {
+    it('renders a pdf for an admin token', async () => {
+      const response = await client.get('/v1/expenses_overview.pdf', {
+        params: { token: admin.token, expenses_overview: { beginning: '2030-01-01', ending: '2030-03-01' } },
+        responseType: 'arraybuffer',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toContain('pdf');
+    });
+
+    it('is admin-only', async () => {
+      const response = await client.get('/v1/expenses_overview.pdf', {
+        params: {
+          token: civilServant.token,
+          expenses_overview: { beginning: '2030-01-01', ending: '2030-03-01' },
+        },
+      });
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('GET /v1/export_certificate/:id', () => {
+    it('is unauthenticated-rejected', async () => {
+      const response = await client.get(`/v1/export_certificate/${serviceId}`);
+
+      expect(response.status).toBe(401);
+    });
+
+    it('is admin-only', async () => {
+      const response = await client.get(`/v1/export_certificate/${serviceId}`, {
+        headers: authHeaders(civilServant.token),
+      });
+
+      expect(response.status).toBe(401);
+    });
+
+    it('does not error for an admin requesting an existing service', async () => {
+      const response = await client.get(`/v1/export_certificate/${serviceId}`, {
+        headers: authHeaders(admin.token),
+      });
+
+      expect(response.status).not.toBe(401);
+      expect(response.status).not.toBe(404);
+    });
+
+    it('renders a 404 for a non-existent service', async () => {
+      const response = await client.get('/v1/export_certificate/-1', { headers: authHeaders(admin.token) });
+
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/integration-tests/tests/holidays.test.ts
+++ b/integration-tests/tests/holidays.test.ts
@@ -1,0 +1,74 @@
+import { client, authHeaders } from '../src/client';
+import { Session } from '../src/auth';
+import { registerAndSignInCivilServant } from '../src/fixtures';
+
+// NOTE: HolidaysController has no admin restriction — any authenticated user
+// (civil servant or admin) can create/update/destroy holidays. That's
+// existing behavior, captured here as the contract, not something this
+// suite is asserting *should* be true.
+describe('V1::HolidaysController', () => {
+  let civilServant: Session;
+
+  beforeAll(async () => {
+    civilServant = await registerAndSignInCivilServant();
+  });
+
+  it('rejects unauthenticated access', async () => {
+    const response = await client.get('/v1/holidays');
+
+    expect(response.status).toBe(401);
+  });
+
+  it('supports create, list, update and destroy for an authenticated civil servant', async () => {
+    const headers = authHeaders(civilServant.token);
+
+    const createResponse = await client.post(
+      '/v1/holidays',
+      {
+        holiday: {
+          beginning: '2031-01-01',
+          ending: '2031-01-01',
+          holiday_type: 'public_holiday',
+          description: 'integration-test-holiday',
+        },
+      },
+      { headers }
+    );
+    expect(createResponse.status).toBe(201);
+    const holidayId = createResponse.data.id;
+
+    const indexResponse = await client.get('/v1/holidays', { headers });
+    expect(indexResponse.status).toBe(200);
+    expect(indexResponse.data).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: holidayId, description: 'integration-test-holiday' })])
+    );
+
+    const updateResponse = await client.put(
+      `/v1/holidays/${holidayId}`,
+      { holiday: { description: 'updated-by-integration-test' } },
+      { headers }
+    );
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.data.description).toBe('updated-by-integration-test');
+
+    const destroyResponse = await client.delete(`/v1/holidays/${holidayId}`, { headers });
+    expect(destroyResponse.status).toBe(204);
+  });
+
+  it('rejects an invalid holiday_type with a structured validation error', async () => {
+    const response = await client.post(
+      '/v1/holidays',
+      {
+        holiday: {
+          beginning: '2031-02-01',
+          ending: '2031-02-01',
+          holiday_type: 'not-a-real-type',
+          description: 'invalid',
+        },
+      },
+      { headers: authHeaders(civilServant.token) }
+    );
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/integration-tests/tests/passwordReset.test.ts
+++ b/integration-tests/tests/passwordReset.test.ts
@@ -1,0 +1,46 @@
+import { client } from '../src/client';
+import { signIn } from '../src/auth';
+import { registerCivilServant } from '../src/fixtures';
+import { waitForPasswordResetToken } from '../src/mail';
+
+describe('Devise password reset', () => {
+  it('lets a user reset their password via the emailed token, end to end', async () => {
+    const user = await registerCivilServant();
+
+    const requestedAt = new Date();
+    const requestResponse = await client.post('/v1/users/password', { user: { email: user.email } });
+    expect(requestResponse.status).toBe(201);
+
+    const token = await waitForPasswordResetToken(requestedAt);
+
+    const newPassword = 'a-brand-new-password-123';
+    const resetResponse = await client.put('/v1/users/password', {
+      user: { reset_password_token: token, password: newPassword, password_confirmation: newPassword },
+    });
+    expect(resetResponse.status).toBe(204);
+
+    const oldPasswordLogin = await client.post('/v1/users/sign_in', {
+      user: { email: user.email, password: user.password },
+    });
+    expect(oldPasswordLogin.status).toBe(401);
+
+    const session = await signIn({ email: user.email, password: newPassword });
+    expect(session.userId).toEqual(expect.any(Number));
+  });
+
+  it('does not error for an unknown email (no user enumeration signal via status code)', async () => {
+    const response = await client.post('/v1/users/password', {
+      user: { email: 'no-such-user@example.com' },
+    });
+
+    expect(response.status).toBe(201);
+  });
+
+  it('rejects an invalid reset token', async () => {
+    const response = await client.put('/v1/users/password', {
+      user: { reset_password_token: 'not-a-real-token', password: 'whatever123', password_confirmation: 'whatever123' },
+    });
+
+    expect(response.status).toBe(422);
+  });
+});

--- a/integration-tests/tests/payments.test.ts
+++ b/integration-tests/tests/payments.test.ts
@@ -1,0 +1,118 @@
+import { client, authHeaders } from '../src/client';
+import { Session, signInAsAdmin } from '../src/auth';
+import {
+  createConfirmedService,
+  createServiceSpecification,
+  registerCivilServant,
+  registerAndSignInCivilServant,
+} from '../src/fixtures';
+
+describe('V1::PaymentsController', () => {
+  let admin: Session;
+  let civilServant: Session;
+  let serviceSpecificationId: number;
+  let weeksFromNow = 560;
+
+  // Payment#payment_timestamp is floored to the whole second
+  // (Payment.floor_time) and there's nothing else to key a payment by, so
+  // two `POST /v1/payments` calls landing in the same wall-clock second
+  // would collide and get merged into one payment. This suite runs fast
+  // enough for that to actually happen, so force a fresh second first.
+  async function waitForNextSecond(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 1000 - (Date.now() % 1000) + 50));
+  }
+
+  async function createReadyForPaymentExpenseSheet(): Promise<number> {
+    const user = await registerCivilServant();
+    await createConfirmedService(admin.token, user.id, serviceSpecificationId, weeksFromNow++);
+
+    const userResponse = await client.get(`/v1/users/${user.id}`, { headers: authHeaders(admin.token) });
+    const expenseSheetId = userResponse.data.expense_sheets[0].id;
+
+    await client.put(
+      `/v1/expense_sheets/${expenseSheetId}`,
+      { expense_sheet: { state: 'ready_for_payment', work_days: 1 } },
+      { headers: authHeaders(admin.token) }
+    );
+
+    return expenseSheetId;
+  }
+
+  beforeAll(async () => {
+    admin = await signInAsAdmin();
+    civilServant = await registerAndSignInCivilServant();
+    serviceSpecificationId = await createServiceSpecification(admin.token);
+  });
+
+  it('rejects a civil servant from the payments index', async () => {
+    const response = await client.get('/v1/payments', { headers: authHeaders(civilServant.token) });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('lets an admin list payments', async () => {
+    const response = await client.get('/v1/payments', { headers: authHeaders(admin.token) });
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.data)).toBe(true);
+  });
+
+  it('takes a ready_for_payment expense sheet through create -> confirm', async () => {
+    await waitForNextSecond();
+    await createReadyForPaymentExpenseSheet();
+
+    const createPaymentResponse = await client.post('/v1/payments', {}, { headers: authHeaders(admin.token) });
+    // NB: PaymentsController#create passes `state: :created` (not `status:`) to
+    // `render`, so Rails silently ignores it and responds 200 rather than 201.
+    // Captured here as the current contract, not asserting it's correct.
+    expect(createPaymentResponse.status).toBe(200);
+    expect(createPaymentResponse.data.state).toBe('payment_in_progress');
+    const paymentTimestamp = createPaymentResponse.data.payment_timestamp;
+
+    const confirmResponse = await client.put(
+      `/v1/payments/${paymentTimestamp}/confirm`,
+      {},
+      { headers: authHeaders(admin.token) }
+    );
+    expect(confirmResponse.status).toBe(200);
+    expect(confirmResponse.data.state).toBe('paid');
+  });
+
+  it('shows a payment as json, and exports the pain XML via a token', async () => {
+    await waitForNextSecond();
+    await createReadyForPaymentExpenseSheet();
+    const createPaymentResponse = await client.post('/v1/payments', {}, { headers: authHeaders(admin.token) });
+    const paymentTimestamp = createPaymentResponse.data.payment_timestamp;
+
+    const showResponse = await client.get(`/v1/payments/${paymentTimestamp}`, { headers: authHeaders(admin.token) });
+    expect(showResponse.status).toBe(200);
+    expect(showResponse.data).toEqual(
+      expect.objectContaining({ payment_timestamp: paymentTimestamp, state: 'payment_in_progress' })
+    );
+
+    const xmlResponse = await client.get(`/v1/payments/${paymentTimestamp}.xml`, {
+      params: { token: admin.token },
+      responseType: 'arraybuffer',
+    });
+    expect(xmlResponse.status).toBe(200);
+    expect(xmlResponse.headers['content-type']).toContain('xml');
+  });
+
+  it('cancels a payment back to ready_for_payment', async () => {
+    await waitForNextSecond();
+    await createReadyForPaymentExpenseSheet();
+    const createPaymentResponse = await client.post('/v1/payments', {}, { headers: authHeaders(admin.token) });
+    const paymentTimestamp = createPaymentResponse.data.payment_timestamp;
+
+    const cancelResponse = await client.delete(`/v1/payments/${paymentTimestamp}`, {
+      headers: authHeaders(admin.token),
+    });
+    expect(cancelResponse.status).toBe(200);
+    expect(cancelResponse.data.state).toBe('ready_for_payment');
+
+    const showAfterCancel = await client.get(`/v1/payments/${paymentTimestamp}`, {
+      headers: authHeaders(admin.token),
+    });
+    expect(showAfterCancel.status).toBe(404);
+  });
+});

--- a/integration-tests/tests/regionalCenters.test.ts
+++ b/integration-tests/tests/regionalCenters.test.ts
@@ -1,0 +1,20 @@
+import { client } from '../src/client';
+import { BOOTSTRAP_REGIONAL_CENTER_SHORT_NAME } from '../src/fixtures';
+
+describe('GET /v1/regional_centers', () => {
+  it('publicly lists regional centers, including the bootstrapped one', async () => {
+    const response = await client.get('/v1/regional_centers');
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.data)).toBe(true);
+    expect(response.data.length).toBeGreaterThanOrEqual(1);
+
+    for (const center of response.data) {
+      expect(Object.keys(center).sort()).toEqual(['address', 'id', 'name', 'short_name']);
+    }
+
+    expect(response.data).toEqual(
+      expect.arrayContaining([expect.objectContaining({ short_name: BOOTSTRAP_REGIONAL_CENTER_SHORT_NAME })])
+    );
+  });
+});

--- a/integration-tests/tests/serviceSpecifications.test.ts
+++ b/integration-tests/tests/serviceSpecifications.test.ts
@@ -1,0 +1,97 @@
+import { client, authHeaders } from '../src/client';
+import { Session, signInAsAdmin } from '../src/auth';
+import { createServiceSpecification, registerAndSignInCivilServant } from '../src/fixtures';
+
+const dayExpenses = { breakfast: 0, lunch: 0, dinner: 0 };
+
+describe('V1::ServiceSpecificationsController', () => {
+  let civilServant: Session;
+  let admin: Session;
+  let seedSpecId: number;
+
+  beforeAll(async () => {
+    civilServant = await registerAndSignInCivilServant();
+    admin = await signInAsAdmin();
+    seedSpecId = await createServiceSpecification(admin.token);
+  });
+
+  it('lists specifications for any authenticated user', async () => {
+    const response = await client.get('/v1/service_specifications', {
+      headers: authHeaders(civilServant.token),
+    });
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.data)).toBe(true);
+    expect(response.data).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: seedSpecId, pocket_money: expect.any(Number) })])
+    );
+  });
+
+  it('shows a single specification', async () => {
+    const response = await client.get(`/v1/service_specifications/${seedSpecId}`, {
+      headers: authHeaders(civilServant.token),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.data.id).toBe(seedSpecId);
+  });
+
+  it('forbids a civil servant from creating a specification', async () => {
+    const response = await client.post(
+      '/v1/service_specifications',
+      {
+        service_specification: {
+          name: 'Should Not Be Created',
+          short_name: 'X',
+          identification_number: '00000',
+          work_clothing_expenses: 0,
+          accommodation_expenses: 0,
+          location: 'zurich',
+          active: true,
+          work_days_expenses: dayExpenses,
+          paid_vacation_expenses: dayExpenses,
+          first_day_expenses: dayExpenses,
+          last_day_expenses: dayExpenses,
+        },
+      },
+      { headers: authHeaders(civilServant.token) }
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('lets an admin create and then update a specification', async () => {
+    const suffix = Date.now();
+    const createResponse = await client.post(
+      '/v1/service_specifications',
+      {
+        service_specification: {
+          name: `Integration Test Spec ${suffix}`,
+          short_name: 'IT',
+          identification_number: `${suffix}`.slice(-5),
+          work_clothing_expenses: 0,
+          accommodation_expenses: 0,
+          location: 'zurich',
+          active: true,
+          work_days_expenses: dayExpenses,
+          paid_vacation_expenses: dayExpenses,
+          first_day_expenses: dayExpenses,
+          last_day_expenses: dayExpenses,
+        },
+      },
+      { headers: authHeaders(admin.token) }
+    );
+
+    expect(createResponse.status).toBe(201);
+    const specId = createResponse.data.id;
+
+    const updateResponse = await client.put(
+      `/v1/service_specifications/${specId}`,
+      { service_specification: { active: false } },
+      { headers: authHeaders(admin.token) }
+    );
+
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.data.active).toBe(false);
+  });
+});

--- a/integration-tests/tests/services.test.ts
+++ b/integration-tests/tests/services.test.ts
@@ -31,7 +31,7 @@ describe('V1::ServicesController', () => {
     expect(response.data).toEqual({ result: expect.any(Number) });
   });
 
-  it('lets an admin create, confirm and cancel-by-overlap a service for a fresh user', async () => {
+  it('lets an admin create and confirm a service, and rejects an overlapping create', async () => {
     const user = await registerCivilServant();
     const { beginning, ending } = normalServiceRange(520);
 
@@ -162,7 +162,7 @@ describe('V1::ServicesController', () => {
     expect(pdfResponse.headers['content-type']).toContain('pdf');
 
     const newEnding = new Date(service.ending);
-    newEnding.setDate(newEnding.getDate() + 7);
+    newEnding.setUTCDate(newEnding.getUTCDate() + 7);
     const newEndingIso = newEnding.toISOString().slice(0, 10);
     const recalculated = await client.get('/v1/services/calculate_service_days', {
       params: { beginning: service.beginning, ending: newEndingIso },

--- a/integration-tests/tests/services.test.ts
+++ b/integration-tests/tests/services.test.ts
@@ -1,0 +1,193 @@
+import { client, authHeaders } from '../src/client';
+import { Session, signInAsAdmin } from '../src/auth';
+import {
+  createService,
+  createServiceSpecification,
+  registerCivilServant,
+  registerAndSignInCivilServant,
+} from '../src/fixtures';
+import { normalServiceRange } from '../src/dates';
+
+describe('V1::ServicesController', () => {
+  let admin: Session;
+  let civilServant: Session;
+  let serviceSpecificationId: number;
+
+  beforeAll(async () => {
+    admin = await signInAsAdmin();
+    civilServant = await registerAndSignInCivilServant();
+    serviceSpecificationId = await createServiceSpecification(admin.token);
+  });
+
+  it('calculates chargeable service days for a date range', async () => {
+    const { beginning, ending } = normalServiceRange(500);
+
+    const response = await client.get('/v1/services/calculate_service_days', {
+      params: { beginning, ending },
+      headers: authHeaders(admin.token),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.data).toEqual({ result: expect.any(Number) });
+  });
+
+  it('lets an admin create, confirm and cancel-by-overlap a service for a fresh user', async () => {
+    const user = await registerCivilServant();
+    const { beginning, ending } = normalServiceRange(520);
+
+    const calculated = await client.get('/v1/services/calculate_service_days', {
+      params: { beginning, ending },
+      headers: authHeaders(admin.token),
+    });
+    const serviceDays = calculated.data.result;
+
+    const createResponse = await client.post(
+      '/v1/services',
+      {
+        service: {
+          user_id: user.id,
+          service_specification_id: serviceSpecificationId,
+          beginning,
+          ending,
+          service_type: 'normal',
+          service_days: serviceDays,
+          first_swo_service: true,
+          long_service: false,
+          probation_service: false,
+        },
+      },
+      { headers: authHeaders(admin.token) }
+    );
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.data).toMatchObject({
+      user_id: user.id,
+      beginning,
+      ending,
+      confirmation_date: null,
+    });
+    const serviceId = createResponse.data.id;
+
+    const overlapResponse = await client.post(
+      '/v1/services',
+      {
+        service: {
+          user_id: user.id,
+          service_specification_id: serviceSpecificationId,
+          beginning,
+          ending,
+          service_type: 'normal',
+          service_days: serviceDays,
+          first_swo_service: true,
+          long_service: false,
+          probation_service: false,
+        },
+      },
+      { headers: authHeaders(admin.token) }
+    );
+    expect(overlapResponse.status).toBe(400);
+    expect(overlapResponse.data).toEqual(
+      expect.objectContaining({ errors: expect.any(Object), human_readable_descriptions: expect.any(Array) })
+    );
+
+    const confirmResponse = await client.put(
+      `/v1/services/${serviceId}/confirm`,
+      {},
+      { headers: authHeaders(admin.token) }
+    );
+    expect(confirmResponse.status).toBe(200);
+    expect(confirmResponse.data.confirmation_date).not.toBeNull();
+
+    const userResponse = await client.get(`/v1/users/${user.id}`, { headers: authHeaders(admin.token) });
+    expect(userResponse.data.expense_sheets.length).toBeGreaterThan(0);
+  });
+
+  it('lets an admin destroy an unconfirmed service', async () => {
+    const user = await registerCivilServant();
+    const { beginning, ending } = normalServiceRange(525);
+    const calculated = await client.get('/v1/services/calculate_service_days', {
+      params: { beginning, ending },
+      headers: authHeaders(admin.token),
+    });
+
+    const createResponse = await client.post(
+      '/v1/services',
+      {
+        service: {
+          user_id: user.id,
+          service_specification_id: serviceSpecificationId,
+          beginning,
+          ending,
+          service_type: 'normal',
+          service_days: calculated.data.result,
+          first_swo_service: true,
+          long_service: false,
+          probation_service: false,
+        },
+      },
+      { headers: authHeaders(admin.token) }
+    );
+    expect(createResponse.data.deletable).toBe(true);
+
+    const destroyResponse = await client.delete(`/v1/services/${createResponse.data.id}`, {
+      headers: authHeaders(admin.token),
+    });
+    expect(destroyResponse.status).toBe(204);
+  });
+
+  it('calculates an ending date for a given number of service days', async () => {
+    const { beginning } = normalServiceRange(530);
+
+    const response = await client.get('/v1/services/calculate_ending', {
+      params: { beginning, service_days: 26 },
+      headers: authHeaders(admin.token),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.data).toEqual({ result: expect.any(String) });
+  });
+
+  it('shows a single service as json and pdf, and lets an admin update it', async () => {
+    const user = await registerCivilServant();
+    const service = await createService(admin.token, user.id, serviceSpecificationId, 535);
+
+    const showResponse = await client.get(`/v1/services/${service.id}`, { headers: authHeaders(admin.token) });
+    expect(showResponse.status).toBe(200);
+    expect(showResponse.data.id).toBe(service.id);
+
+    const pdfResponse = await client.get(`/v1/services/${service.id}.pdf`, {
+      params: { token: admin.token },
+    });
+    expect(pdfResponse.status).toBe(200);
+    expect(pdfResponse.headers['content-type']).toContain('pdf');
+
+    const newEnding = new Date(service.ending);
+    newEnding.setDate(newEnding.getDate() + 7);
+    const newEndingIso = newEnding.toISOString().slice(0, 10);
+    const recalculated = await client.get('/v1/services/calculate_service_days', {
+      params: { beginning: service.beginning, ending: newEndingIso },
+      headers: authHeaders(admin.token),
+    });
+
+    const updateResponse = await client.put(
+      `/v1/services/${service.id}`,
+      { service: { ending: newEndingIso, service_days: recalculated.data.result } },
+      { headers: authHeaders(admin.token) }
+    );
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.data.ending).toBe(newEndingIso);
+  });
+
+  it('forbids a civil servant from viewing the services index', async () => {
+    const response = await client.get('/v1/services', { headers: authHeaders(civilServant.token) });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('lets an admin view the services index', async () => {
+    const response = await client.get('/v1/services', { headers: authHeaders(admin.token) });
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.data)).toBe(true);
+  });
+});

--- a/integration-tests/tests/users.test.ts
+++ b/integration-tests/tests/users.test.ts
@@ -1,0 +1,122 @@
+import { client, authHeaders } from '../src/client';
+import { Session, signIn, signInAsAdmin } from '../src/auth';
+import { registerCivilServant } from '../src/fixtures';
+
+describe('V1::UsersController', () => {
+  let civilServant: Session;
+  let civilServantEmail: string;
+  let admin: Session;
+
+  beforeAll(async () => {
+    const user = await registerCivilServant();
+    civilServantEmail = user.email;
+    civilServant = await signIn(user);
+    admin = await signInAsAdmin();
+  });
+
+  describe('#show', () => {
+    it('lets a civil servant view themselves, including nested services/expense_sheets', async () => {
+      const response = await client.get(`/v1/users/${civilServant.userId}`, {
+        headers: authHeaders(civilServant.token),
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data).toMatchObject({
+        id: civilServant.userId,
+        email: civilServantEmail,
+        role: 'civil_servant',
+      });
+      expect(Array.isArray(response.data.services)).toBe(true);
+      expect(Array.isArray(response.data.expense_sheets)).toBe(true);
+    });
+
+    it('forbids a civil servant from viewing another user', async () => {
+      const response = await client.get(`/v1/users/${admin.userId}`, {
+        headers: authHeaders(civilServant.token),
+      });
+
+      expect(response.status).toBe(401);
+      expect(response.data).toHaveProperty('error');
+    });
+
+    it('lets an admin view any user', async () => {
+      const response = await client.get(`/v1/users/${civilServant.userId}`, {
+        headers: authHeaders(admin.token),
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data.id).toBe(civilServant.userId);
+    });
+
+    it('renders a 404 for a non-existent user', async () => {
+      const response = await client.get('/v1/users/-1', { headers: authHeaders(admin.token) });
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('#index', () => {
+    it('is admin-only', async () => {
+      const response = await client.get('/v1/users', { headers: authHeaders(civilServant.token) });
+
+      expect(response.status).toBe(401);
+    });
+
+    it('lists users for an admin', async () => {
+      const response = await client.get('/v1/users', { headers: authHeaders(admin.token) });
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.data)).toBe(true);
+      expect(response.data.length).toBeGreaterThanOrEqual(2);
+      expect(response.data[0]).toEqual(
+        expect.objectContaining({ id: expect.any(Number), zdp: expect.any(Number), role: expect.any(String) })
+      );
+    });
+  });
+
+  describe('#destroy', () => {
+    it('is admin-only', async () => {
+      const victim = await registerCivilServant();
+      const response = await client.delete(`/v1/users/${victim.id}`, { headers: authHeaders(civilServant.token) });
+
+      expect(response.status).toBe(401);
+    });
+
+    it('lets an admin delete a user with no services', async () => {
+      const victim = await registerCivilServant();
+      const response = await client.delete(`/v1/users/${victim.id}`, { headers: authHeaders(admin.token) });
+
+      expect(response.status).toBe(204);
+    });
+
+    it('forbids an admin from deleting themselves', async () => {
+      const response = await client.delete(`/v1/users/${admin.userId}`, { headers: authHeaders(admin.token) });
+
+      expect(response.status).toBe(400);
+      expect(response.data).toEqual(
+        expect.objectContaining({
+          errors: expect.any(Object),
+          human_readable_descriptions: expect.any(Array),
+        })
+      );
+    });
+  });
+
+  describe('#update validation', () => {
+    it('renders a structured 400 for invalid data', async () => {
+      const response = await client.put(
+        `/v1/users/${civilServant.userId}`,
+        { user: { zip: 'not-a-number' } },
+        { headers: authHeaders(civilServant.token) }
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.data).toEqual(
+        expect.objectContaining({
+          errors: expect.any(Object),
+          human_readable_descriptions: expect.any(Array),
+        })
+      );
+    });
+  });
+});

--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "lib": ["ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
## Summary

Step 1 of the [Rails major version upgrade process](https://github.com/stiftungswo/better-izivi/blob/develop/RAILS_UPGRADE_PROCESS.md) (added in this PR): a black-box HTTP integration test suite, written in TypeScript so it's unaffected by the Ruby/Rails upgrade it exists to guard.

- **Full route coverage** — every entry in `bin/rails routes` that's actual application surface, cross-checked route by route: auth (sign in/out, JWT revocation, self-registration, password reset, Devise's self-service profile update/delete), users, regional centers, holidays, service specifications, services, expense sheets, payments (including the pain/XML bank export), and every PDF export. The only routes excluded are Sidekiq's web UI and default Rails ActiveStorage routes, which aren't used by this domain.
- **Does not depend on `rails db:seed`** — a Jest `globalSetup` bootstraps the one fixture the API has no endpoint for (a `RegionalCenter`) and one admin account directly over SQL, bypassing ActiveRecord entirely. Everything else is created by the tests through the API itself. This matters because `db:seed` is Ruby application code that can be broken by exactly the kind of regression this suite exists to catch — see the included fix for a `service_days` seed bug that had been silently broken on `develop` because nothing exercises `db:seed` in CI or specs.
- **DIME integration tested for real, not skipped** — `dimeSickDays.test.ts` spins up a local self-signed HTTPS mock implementing DIME's three endpoints and temporarily recreates the `api` container with `API_URI_DIME` pointed at it (restoring the default afterwards). Required one small, backwards-compatible change to `docker-compose.yml` (`API_URI_DIME` is now overridable via env var, same default as before).

All 69 tests pass against the current app on a database with only the schema loaded. See `integration-tests/README.md` for how to run it and notes on a few existing quirks the tests document as current contract (not asserted as correct) rather than fix.

## Test plan

- [x] `npm test` passes (69/69) against a freshly schema-loaded database
- [x] `npm test` passes against a `db:seed`-ed database too
- [x] Full suite is stable across repeated runs on a persisted database
- [x] `tsc --noEmit` clean
- [x] Verified the `api` container is correctly restored after the DIME mock test, both on success and by inspecting `docker exec ... env` afterward


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Jest/TypeScript black-box HTTP integration test suite covering authentication, profiles, regional centers, services workflows, service specifications, holidays, payments, expense sheets, exports, and password reset.
  * Added end-to-end support for a local HTTPS DIME API mock (including request recording and response simulation).
* **Bug Fixes**
  * Improved service seed data to include correctly computed service-day values.
* **Documentation**
  * Added guides for integration test setup and a step-by-step Rails API upgrade process.
* **Chores**
  * Updated Docker configuration to allow overriding the DIME endpoint via an environment default, and ignored `node_modules` in integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->