### PR TITLE
Internalize the feedback-mail cron schedule

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -27,6 +27,7 @@ gem 'rails', '6.1.6.1'
 gem 'rails-i18n'
 gem 'sepa_king'
 gem 'sidekiq', '~> 6.5'
+gem 'sidekiq-cron', '~> 1.9'
 gem 'validates_timeliness'
 
 group :production do

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
     dry-core (0.8.1)
       concurrent-ruby (~> 1.0)
     erubi (1.11.0)
+    et-orbi (1.4.0)
+      tzinfo
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -140,6 +142,9 @@ GEM
     faraday-net_http (3.0.0)
     ffi (1.15.5)
     ffi (1.15.5-x64-mingw32)
+    fugit (1.12.3)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     geom2d (0.3.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -231,6 +236,7 @@ GEM
     public_suffix (5.0.0)
     puma (6.4.3)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.6.0)
     rack (2.2.4)
     rack-cors (1.1.1)
@@ -342,6 +348,9 @@ GEM
       connection_pool (>= 2.2.5)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
+    sidekiq-cron (1.9.1)
+      fugit (~> 1.8)
+      sidekiq (>= 4.2.1)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -436,6 +445,7 @@ DEPENDENCIES
   sepa_king
   shoulda-matchers
   sidekiq (~> 6.5)
+  sidekiq-cron (~> 1.9)
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/api/app/jobs/application_job.rb
+++ b/api/app/jobs/application_job.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationJob < ActiveJob::Base
+end

--- a/api/app/jobs/send_feedback_reminders_job.rb
+++ b/api/app/jobs/send_feedback_reminders_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SendFeedbackRemindersJob < ApplicationJob
+  queue_as :mailers
+
+  def perform
+    FeedbackReminderMailSenderService.new.send_reminders
+  end
+end

--- a/api/config/initializers/sidekiq.rb
+++ b/api/config/initializers/sidekiq.rb
@@ -6,4 +6,11 @@ if defined? Sidekiq
   Sidekiq::Web.use(Rack::Auth::Basic) do |user, password|
     [user, password] == [ENV.fetch('SIDEKIQ_USER', nil), ENV.fetch('SIDEKIQ_PASSWORD', nil)]
   end
+
+  # Recurring jobs (config/schedule.yml) — only the worker process needs to
+  # load these into Sidekiq-Cron's Redis-backed schedule, not the web dyno.
+  if Sidekiq.server?
+    schedule_file = Rails.root.join('config/schedule.yml')
+    Sidekiq::Cron::Job.load_from_hash(YAML.load_file(schedule_file)) if File.exist?(schedule_file)
+  end
 end

--- a/api/config/schedule.yml
+++ b/api/config/schedule.yml
@@ -1,0 +1,5 @@
+send_feedback_reminders:
+  cron: "0 8 * * mon"
+  class: "SendFeedbackRemindersJob"
+  queue: mailers
+  description: "Weekly feedback reminder mail for services that ended and haven't been reminded yet"

--- a/api/spec/jobs/send_feedback_reminders_job_spec.rb
+++ b/api/spec/jobs/send_feedback_reminders_job_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SendFeedbackRemindersJob, type: :job do
+  describe '#perform' do
+    let(:service) { instance_double(FeedbackReminderMailSenderService, send_reminders: true) }
+
+    before { allow(FeedbackReminderMailSenderService).to receive(:new).and_return(service) }
+
+    it 'delegates to FeedbackReminderMailSenderService#send_reminders' do
+      described_class.new.perform
+
+      expect(service).to have_received(:send_reminders)
+    end
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
         build:
             context: ./api
             dockerfile: dev.Dockerfile
+        image: better-izivi-api-dev
         container_name: better_izivi_api
         volumes:
             - ./api:/api
@@ -11,13 +12,14 @@ services:
         command: "rails server -p 8000 -b 0.0.0.0"
         depends_on:
             - mysql
+            - redis
         ports:
             - "28000:8000"
             - "1234:1234"
             - "26162:26162"
         extra_hosts:
           - "localhost:192.168.56.1"
-        environment:
+        environment: &api_env
             - DATABASE_HOST=mysql
             - DATABASE_USERNAME=root
             - DATABASE_PASSWORD=
@@ -43,6 +45,25 @@ services:
             - PASSWORD_DIME=123456
             - CONNECT_TO_DIME=false
             - API_URI_DIME=https://dime-apir-develop.stiftungswo.ch
+            - REDIS_URL=redis://redis:6379/0
+
+    worker:
+        image: better-izivi-api-dev
+        container_name: better_izivi_worker
+        volumes:
+            - ./api:/api
+        working_dir: /api
+        command: "bundle exec sidekiq -C config/sidekiq.yml"
+        depends_on:
+            - mysql
+            - redis
+        environment: *api_env
+
+    redis:
+        image: redis:6.2.5-alpine
+        container_name: better_izivi_redis
+        ports:
+            - "26379:6379"
 
     frontend:
         image: node:10


### PR DESCRIPTION
## Summary

While debugging a prod feedback-mail failure, the trigger turned out to be a system crontab entry on the old host, invisible from this repo:

```
0 8 * * mon docker exec better_izivi_master_api bin/bundle exec rake feedback_mail:send > /dev/null
```

That's exactly the kind of thing that gets lost across host migrations — it had to be dug up manually. This moves the schedule into the app instead:

- Adds `sidekiq-cron` and `config/schedule.yml` (`0 8 * * mon`), loaded by the worker process on boot.
- Adds `SendFeedbackRemindersJob` (+ `ApplicationJob`, which didn't exist yet) wrapping the existing `FeedbackReminderMailSenderService` — the same logic the rake task already called, now also reachable as a proper background job.
- The rake task (`feedback_mail:send`) is untouched and still works for manual/debugging use.
- Adds `redis` and `worker` services to the dev `docker-compose.yml` (sharing the `api` image via a YAML anchor) so this is actually runnable and testable locally — the new prod hosting setup already runs both, so this needed no new infra there.

## Test plan

- [x] `bundle exec rubocop` clean, full codebase
- [x] `docker compose up -d mysql redis api worker` — worker boots and logs `Cron Jobs - added job with name: send_feedback_reminders`
- [x] Created a throwaway past-dated `Service` with `feedback_mail_sent: false`, ran `SendFeedbackRemindersJob.perform_now` — confirmed `feedback_mail_sent` flipped to `true` and the reminder mail was rendered (dev uses `letter_opener`, so no real SMTP send)
- [x] Enqueued the job from the `api` process via `perform_later` and confirmed the separate `worker` container picked it up and completed it on the `mailers` queue
- [x] Cleaned up the throwaway test fixtures afterward

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated weekly feedback reminder emails for eligible services.
  * Enabled scheduled background processing for recurring reminder delivery.
* **Infrastructure / Chores**
  * Added support for running background workers alongside the API, including a Redis service for job execution.
  * Updated recurring job scheduling to run only in the background worker environment.
* **Tests**
  * Added coverage to verify the scheduled reminder job delegates to the reminder sender service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->