### PR TITLE
Show sidekiq-cron schedule in the Sidekiq web UI

### DIFF
--- a/api/config/initializers/sidekiq.rb
+++ b/api/config/initializers/sidekiq.rb
@@ -2,6 +2,7 @@
 
 if defined? Sidekiq
   require 'sidekiq/web'
+  require 'sidekiq/cron/web'
 
   Sidekiq::Web.use(Rack::Auth::Basic) do |user, password|
     [user, password] == [ENV.fetch('SIDEKIQ_USER', nil), ENV.fetch('SIDEKIQ_PASSWORD', nil)]


### PR DESCRIPTION
## Summary
- `require 'sidekiq/cron/web'` was missing from `config/initializers/sidekiq.rb`, so the Sidekiq dashboard never showed a "Cron" tab — the internalized `send_feedback_reminders` schedule (added in #569) was loading into Redis correctly, but had no visible entry point in the web UI.

## Test plan
- [x] Verified locally: without the require, `/sidekiq` has no Cron nav link. With it, `/sidekiq/cron` lists `send_feedback_reminders` correctly.