### PR TITLE
Replace committed Devise secrets in api/.env.ci with obvious CI placeholders

### DIFF
--- a/api/.env.ci
+++ b/api/.env.ci
@@ -1,9 +1,13 @@
 DATABASE_USERNAME=root
 DATABASE_PASSWORD=
 DATABASE_HOST=mysql
-DEVISE_JWT_SECRET_KEY=bd97138230954d3ae528958f310ae3516a225e14fdefc8fecd46c64a912e0cca5417353f8cc96837410c6ed5db45a690193254c2640f95d9ade2108b2d628f74
-DEVISE_SECRET_KEY=bed75fe2549be45efb516dfac0b6b78f02ffcd4de62302e406b39c5087fa4fb35e8ffa47040b8ad15c56cacd7b136c60ac0d7d01acf7a03cff8959781ae84acc
-DEVISE_PEPPER=51e8d81b65f7362cd51319ed43e0629a3086d33f491ae42591ed74fd4bed4a62ec2ca59f6d8de572ef029e22e9c6485c18af4e05548d572b722865a4f171305a
+# These three are CI-only placeholders, not real secrets. Ephemeral test
+# containers, torn down after every job, so they don't need real entropy -
+# they only need to be obviously non-production so nobody is ever tempted to
+# reuse them as real prod values.
+DEVISE_JWT_SECRET_KEY=ci-only-not-a-real-secret-devise-jwt-key
+DEVISE_SECRET_KEY=ci-only-not-a-real-secret-devise-secret-key
+DEVISE_PEPPER=ci-only-not-a-real-secret-devise-pepper
 MAIL_SENDER=no-reply@stiftungswo.ch
 APP_HOST=localhost
 APP_PORT=3000


### PR DESCRIPTION
## Summary

Follow-up to a finding CodeRabbit raised on #575: `api/.env.ci` had real-looking, high-entropy `DEVISE_JWT_SECRET_KEY`/`DEVISE_SECRET_KEY`/`DEVISE_PEPPER` values committed in plaintext. This content predates #575 (unchanged since the file was `api/.env.semaphore`, itself untouched since 2018), so it wasn't a regression - but committed secrets are a standing risk regardless of when they landed. If any of these values were ever copy-pasted into the real production secrets, this is a permanent, un-rotatable-without-rotating-prod backdoor into auth (in particular the JWT secret - anyone holding it can forge a valid token for any user without a password).

No evidence of production reuse was found: dev's `docker-compose.yml` uses the placeholder `verysecret`, `.env.example` documents generating your own value rather than shipping one, and no production secrets exist anywhere in this repo.

## Approach

Considered wiring real GitHub Actions secret injection, but that's out of proportion here: these values sign tokens for an ephemeral CI container that's destroyed after every job, so they don't need real entropy - they just need to be unmistakably non-production so nobody is ever tempted to reuse them. Replaced the three hex strings with clearly-labeled placeholders (`ci-only-not-a-real-secret-...`) plus a comment explaining why.

## Test plan

- [x] Confirmed no spec asserts against the specific old secret values (`grep` across `api/spec/`)
- [x] Reran the auth-touching suites with the new placeholder values injected as env vars: `users_controller_spec.rb` + `user_spec.rb`, 71 examples, 0 failures - confirms Devise/JWT sign-in still works with a non-hex, human-readable secret

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration configuration to use clearly identified, non-production placeholder security values.
  * Added documentation clarifying that these values are intended only for temporary CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->