### PR TITLE
Run the production API container as a non-root user

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.env
+.env.*
+!.env.example
+
+log/*
+!log/.keep
+tmp/*
+!tmp/.keep
+storage/*
+!storage/.keep
+coverage/
+
+.byebug_history
+config/master.key
+spec/examples.txt

--- a/api/prod.Dockerfile
+++ b/api/prod.Dockerfile
@@ -11,9 +11,14 @@ ENV RACK_ENV=production
 RUN gem install bundler -v "2.6.9" --no-document
 RUN apt-get update && apt-get install -y mariadb-client pdftk
 
+RUN useradd -ms /bin/bash rails
+
 WORKDIR /api
 COPY Gemfile* ./
 COPY . /api
+
+RUN chown -R rails:rails /api /usr/local/bundle
+USER rails
 
 RUN bundle install --jobs=8
 


### PR DESCRIPTION
## Summary

Follow-up to a finding CodeRabbit raised on #572 (DS-0002), deliberately deferred there since it needed its own validation and was out of scope for a Rails/Ruby version-bump PR. Tracked under `RAILS_UPGRADE_PROCESS.md` step 9.

`api/prod.Dockerfile` had no `USER` directive - `bundle install` and the final `CMD` (the actual Rails server handling production traffic) all ran as root inside the container. If an attacker ever found an RCE in the app or a dependency, running as root hands them root inside that container for free, widening the blast radius of any single exploit.

### Changes

- **`api/prod.Dockerfile`**: added a `rails` user, `chown -R`'d `/api` and `/usr/local/bundle` (the base `ruby` image's `GEM_HOME`/`BUNDLE_APP_CONFIG`) before switching users, then run `bundle install` as that user. Same pattern already proven in `dev.Dockerfile`.
- **`api/.dockerignore`** (new - there wasn't one): while testing this, found the build was copying ~115MB of local log files (`test.log`, `development.log`) and dotfiles like `.env` straight into the image on every build. Mirrors the exclusions already in `api/.gitignore` (`log/`, `tmp/`, `coverage/`, `.env*`, `config/master.key`, etc.), keeping `.keep` placeholders so the directory structure survives.

## Test plan

- [x] Image builds clean; `bundle install` completes as `rails` (uid 1000)
- [x] `/api`, `/api/tmp`, `/api/log`, `/usr/local/bundle` all owned by `rails`
- [x] Container boots against a real mysql instance, Puma serves requests (confirmed `ps aux` shows PID 1 owned by `rails`), writes to `log/production.log` at runtime - confirms write permissions work at runtime, not just build-time ownership
- [x] Log/tmp bloat is gone from the image after adding `.dockerignore`
- [x] `dev.Dockerfile` still builds cleanly with the same `.dockerignore` in the shared build context
- [ ] @TheFehr to verify the built image on the stage/test instance before merge (deploy pipeline in `cd_docker.yml` builds this exact Dockerfile on every push to `develop`/`master`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Docker builds now exclude sensitive configuration, temporary files, logs, and local development artifacts.
  * Production containers run as a non-root user to improve runtime security.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->